### PR TITLE
fix: prevent WPML/Polylang settings from overwriting each other

### DIFF
--- a/admin/class-adminclass.php
+++ b/admin/class-adminclass.php
@@ -309,6 +309,36 @@ class AdminClass {
 	}
 
 	/**
+	 * Normalizes a page ID to its default-language equivalent.
+	 *
+	 * When WPML or Polylang is active the admin page dropdown is filtered to the
+	 * current language, so the submitted page ID may be a translation rather than
+	 * the original. Storing the default-language ID lets resolve_multilingual_page_id()
+	 * derive the correct translation at redirect time, regardless of which language
+	 * admin last saved the setting.
+	 *
+	 * @param int $page_id Page ID submitted by the settings form.
+	 * @return int Default-language page ID, or the original ID when no multilingual plugin is active.
+	 */
+	private function normalize_page_id_to_default_language( int $page_id ): int {
+		// WPML: translate submitted ID to the default language before storing.
+		if ( has_filter( 'wpml_object_id' ) ) {
+			$default_lang = apply_filters( 'wpml_default_language', null );
+			$page_id      = (int) apply_filters( 'wpml_object_id', $page_id, 'page', true, $default_lang );
+		}
+
+		// Polylang: translate submitted ID to the default language before storing.
+		if ( function_exists( 'pll_default_language' ) && function_exists( 'pll_get_post' ) ) {
+			$translated = pll_get_post( $page_id, pll_default_language() );
+			if ( $translated ) {
+				$page_id = $translated;
+			}
+		}
+
+		return $page_id;
+	}
+
+	/**
 	 * Updates the redirect mode options.
 	 *
 	 * @param string $mode Mode value (page, url, or empty).
@@ -323,7 +353,7 @@ class AdminClass {
 			switch ( $mode ) {
 				case 'page':
 					$mode_val      = 'page';
-					$mode_page_val = $page;
+					$mode_page_val = (string) $this->normalize_page_id_to_default_language( (int) $page );
 					$mode_url_val  = '';
 					break;
 				case 'url':

--- a/admin/views/settings-global-redirect.php
+++ b/admin/views/settings-global-redirect.php
@@ -18,6 +18,9 @@ $redirect_mode_url  = '';
 if ( 'page' === $redirect_mode ) {
 	$sql_mode_page      = $wpdb->prepare( 'SELECT value FROM ' . $wpdb->prefix . 'custom_404_pro_options WHERE name = %s', 'mode_page' ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 	$redirect_mode_page = $wpdb->get_var( $sql_mode_page ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+	// Resolve the stored default-language ID to the current admin language so
+	// the correct page appears selected when WPML or Polylang is active.
+	$redirect_mode_page = $this->resolve_multilingual_page_id( (int) $redirect_mode_page );
 } elseif ( 'url' === $redirect_mode ) {
 	$sql_mode_url      = $wpdb->prepare( 'SELECT value FROM ' . $wpdb->prefix . 'custom_404_pro_options WHERE name = %s', 'mode_url' ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 	$redirect_mode_url = $wpdb->get_var( $sql_mode_url ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared

--- a/tests/AdminClassTest.php
+++ b/tests/AdminClassTest.php
@@ -42,6 +42,7 @@ class AdminClassTest extends TestCase {
 		$GLOBALS['_test_filters']        = array();
 		$GLOBALS['_pll_get_post_return'] = false;
 		unset( $GLOBALS['_pll_current_language'] );
+		unset( $GLOBALS['_pll_default_language'] );
 	}
 
 	/**
@@ -83,5 +84,68 @@ class AdminClassTest extends TestCase {
 	public function test_resolve_multilingual_page_id_returns_original_when_no_wpml_filter_registered() {
 		$admin = new AdminClass();
 		$this->assertSame( 42, $admin->resolve_multilingual_page_id( 42 ) );
+	}
+
+	// ------------------------------------------------------------------
+	// normalize_page_id_to_default_language
+	// ------------------------------------------------------------------
+
+	/**
+	 * Calls the private normalize_page_id_to_default_language method via reflection.
+	 *
+	 * @param AdminClass $admin   Instance to invoke on.
+	 * @param int        $page_id Page ID to normalize.
+	 * @return int
+	 */
+	private function normalize( AdminClass $admin, int $page_id ): int {
+		$ref    = new ReflectionClass( $admin );
+		$method = $ref->getMethod( 'normalize_page_id_to_default_language' );
+		$method->setAccessible( true );
+		return $method->invoke( $admin, $page_id );
+	}
+
+	/**
+	 * Asserts that the original ID is returned when no multilingual plugin is active.
+	 */
+	public function test_normalize_returns_original_id_when_no_multilingual_plugin_active() {
+		$admin = new AdminClass();
+		$this->assertSame( 42, $this->normalize( $admin, 42 ) );
+	}
+
+	/**
+	 * Asserts that the WPML default-language ID is returned when a WPML filter is registered.
+	 */
+	public function test_normalize_returns_default_language_id_via_wpml() {
+		// Register wpml_default_language filter.
+		add_filter( 'wpml_default_language', function () { return 'en'; } );
+		// Register wpml_object_id filter that returns the default-language page ID.
+		add_filter(
+			'wpml_object_id',
+			function ( $page_id ) {
+				return 5; // Simulate WPML returning the English (default) page for any input.
+			}
+		);
+		$admin = new AdminClass();
+		$this->assertSame( 5, $this->normalize( $admin, 20 ) );
+	}
+
+	/**
+	 * Asserts that the Polylang default-language ID is returned when pll_get_post finds a translation.
+	 */
+	public function test_normalize_returns_default_language_id_via_polylang() {
+		$GLOBALS['_pll_default_language'] = 'en';
+		$GLOBALS['_pll_get_post_return']  = 10; // pll_get_post returns the default-language page.
+		$admin = new AdminClass();
+		$this->assertSame( 10, $this->normalize( $admin, 20 ) );
+	}
+
+	/**
+	 * Asserts that the original ID is returned when Polylang finds no default-language translation.
+	 */
+	public function test_normalize_returns_original_id_when_polylang_finds_no_default_translation() {
+		$GLOBALS['_pll_default_language'] = 'en';
+		$GLOBALS['_pll_get_post_return']  = false; // pll_get_post returns false → no translation.
+		$admin = new AdminClass();
+		$this->assertSame( 20, $this->normalize( $admin, 20 ) );
 	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -44,6 +44,18 @@ function add_filter( string $tag, callable $callback ) {
 }
 
 /**
+ * Stub for WordPress has_filter().
+ *
+ * Returns true when at least one callback is registered for $tag via add_filter().
+ *
+ * @param string $tag The filter hook name.
+ * @return bool
+ */
+function has_filter( string $tag ): bool {
+	return ! empty( $GLOBALS['_test_filters'][ $tag ] );
+}
+
+/**
  * Stub for Polylang pll_get_post().
  *
  * Returns the value of $GLOBALS['_pll_get_post_return']; defaults to false.
@@ -65,6 +77,17 @@ function pll_get_post( int $post_id, string $lang ) { // phpcs:ignore VariableAn
  */
 function pll_current_language(): string {
 	return $GLOBALS['_pll_current_language'] ?? 'en';
+}
+
+/**
+ * Stub for Polylang pll_default_language().
+ *
+ * Returns the value of $GLOBALS['_pll_default_language']; defaults to 'en'.
+ *
+ * @return string
+ */
+function pll_default_language(): string {
+	return $GLOBALS['_pll_default_language'] ?? 'en';
 }
 
 /**


### PR DESCRIPTION
Fixes #82.

## Root cause

When WPML or Polylang is active with per-language domains, each language's admin panel shows only its own language's pages in the page dropdown (the multilingual plugin filters `get_pages()`). Because `mode_page` is a single stored value, saving from the Dutch admin overwrote the German selection and vice versa.

The existing `resolve_multilingual_page_id()` from #93 correctly translates the stored ID at *redirect time*, but the *save side* was still language-specific.

## Fix

**Save side** (`AdminClass::normalize_page_id_to_default_language`)  
Before writing `mode_page` to the database, the submitted ID is translated back to its default-language equivalent via `wpml_object_id` (WPML) or `pll_get_post` (Polylang). This means every language's admin always stores the same canonical ID regardless of which language context saved it.

**Display side** (`settings-global-redirect.php`)  
When rendering the page dropdown, the stored default-language ID is resolved to the current admin language via the existing `resolve_multilingual_page_id()`, so each language's admin sees its own translated page pre-selected.

## Test plan

- [ ] Dutch admin selects Dutch 404 page → German admin selects German 404 page → Dutch admin reopens settings and still sees Dutch page selected
- [ ] Without any multilingual plugin active, behaviour is unchanged
- [ ] All 19 unit tests pass