### PR TITLE
feat: add email notification cooldown to prevent inbox flooding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,47 +1,171 @@
-## Custom 404 Pro
+# Custom 404 Pro
 
 ![Banner](banner-772x250.png "Banner")
 
-Override the default 404 page with **any page** from the Admin Panel or a **Custom URL**.
+Take full control of your WordPress 404 experience. Custom 404 Pro lets you redirect 404 errors to any page on your site or an external URL, log every broken URL your visitors hit, and stay notified — without getting buried in email.
 
-As always, if you do like the plugin, please take a minute and give it a rating. Thanks!
+---
 
-### Features
+## Features
 
-* Log a 404 error
-* Redirect 404 errors using popular redirect codes (301, 302 etc)
-* Export Logs (.csv)
-* Email the WordPress Admin when a 404 occurs
+### 404 Redirect Control
 
-### Installation
+- **Redirect to a WordPress page** — choose any published page from a dropdown; it just works.
+- **Redirect to a custom URL** — point 404s at any external destination.
+- **Configurable HTTP status code** — choose 301, 302, 307, or 308 depending on whether the redirect is permanent or temporary.
+- **Disable redirects entirely** — keep logging active without touching the 404 response.
 
-* Extract the downloaded ZIP file.
-* Copy the ```custom-404-pro``` folder to the ```wp-content/plugins``` directory.
-* Activate from the Plugins Section.
+### 404 Error Logging
 
-### Screenshots
+- **Automatic log capture** — every 404 is recorded with the full request path, referring URL, user agent, and timestamp.
+- **IP address logging** — optionally capture the visitor's IP. Disable it with one checkbox if privacy or GDPR is a concern; logged entries show `N/A` instead.
+- **Searchable, sortable log table** — filter by any column directly from the Logs admin page.
+- **Bulk actions** — delete selected logs, delete all logs, or export everything as a CSV file in one click.
 
-![Activate Plugin](screenshot-1.png "Activate Plugin")
-_Activate Plugin_
+### Email Notifications
 
-![404 Logs](screenshot-2.png "404 Logs")
-_404 Logs_
+- **Admin email alerts** — get notified at your site's admin email address whenever a 404 is logged.
+- **Email cooldown** — configure a quiet period between notifications (15 minutes, 30 minutes, 1 hour, 6 hours, or 24 hours). Once an email is sent, the plugin stays quiet until the cooldown expires — no inbox flooding from bot crawls or broken redirect loops.
 
-![Global Settings](screenshot-3.png "Global Settings")
-_Global Settings_
+### Compatibility
 
-### Support
+- **Multisite** — tables and settings are provisioned per-site on activation and cleaned up per-site on uninstall.
+- **Polylang & WPML** — redirect targets resolve to the correct translated page for the visitor's active language automatically.
+- **Clean uninstall** — all database tables are dropped when the plugin is removed. No orphaned data left behind.
 
-Please open [issues on Github](https://github.com/kunalnagar/custom-404-pro/issues) ONLY. I will not be using the WordPress.org Support Ticket System.
+---
 
-### Rate
+## Installation
 
-Please feel free to star on Github or [leave a rating](https://wordpress.org/plugins/custom-404-pro/).
+1. Download the plugin ZIP from [WordPress.org](https://wordpress.org/plugins/custom-404-pro/) or clone this repository.
+2. Copy the `custom-404-pro` folder to `wp-content/plugins/`.
+3. Activate the plugin from the **Plugins** screen in the WordPress admin.
+4. Navigate to **Custom 404 Pro → Settings** to configure your redirect and notification preferences.
 
-### Donate
+> **Important:** If you ever want to remove the plugin, use **Deactivate → Delete** from the Plugins screen. Do not delete the plugin folder directly — that bypasses the uninstall routine and leaves database tables behind.
 
-Like the plugin? Show your support by donating [here](https://www.paypal.me/kunalnagar/10) (PayPal)
+---
 
-### Changelog
+## Settings Reference
 
-You can find the full changelog [here](https://wordpress.org/plugins/custom-404-pro/changelog/)
+### Redirect Tab
+
+| Setting | Description |
+|---------|-------------|
+| Mode | `None` (logging only), `WordPress Page`, or `URL` |
+| Page | The WordPress page to redirect to (visible when Mode = WordPress Page) |
+| URL | The external URL to redirect to (visible when Mode = URL) |
+
+### General Tab
+
+| Setting | Options | Default | Description |
+|---------|---------|---------|-------------|
+| Email | On / Off | Off | Send an admin notification email on each logged 404 |
+| Email Notification Cooldown | 15 min / 30 min / 1 hour / 6 hours / 24 hours | 1 hour | Minimum time between notification emails |
+| Logging Status | Enabled / Disabled | Disabled | Whether 404 events are captured to the log table |
+| Log IP | On / Off | On | Whether to record the visitor's IP address |
+| Redirect Code | 301 / 302 / 307 / 308 | 302 | HTTP status code used for the redirect |
+
+---
+
+## Screenshots
+
+| | |
+|--|--|
+| ![Activate Plugin](screenshot-1.png) | _Activate the plugin from the WordPress admin_ |
+| ![404 Logs](screenshot-2.png) | _Sortable, searchable log table with bulk actions_ |
+| ![Settings](screenshot-3.png) | _Redirect and notification settings_ |
+
+---
+
+## Frequently Asked Questions
+
+**Why is the 404 redirect not working?**
+
+Some themes (notably Divi) intercept the request before the `template_redirect` hook fires. Try switching to a default theme to confirm the plugin is working, then re-enable your theme and check for conflicts with theme-level 404 handling.
+
+**Why are my settings not saving after reinstallation?**
+
+Always use **Deactivate → Delete** from the Plugins screen — never remove the plugin folder manually. Manual removal skips the uninstall routine, leaving old database tables in place. When the plugin is reinstalled, it detects the existing tables and skips seeding defaults, so you end up with stale data.
+
+**Can I disable email notifications without disabling logging?**
+
+Yes. Uncheck **Email** in General settings. Logging continues independently.
+
+**How does the email cooldown work?**
+
+After an email notification is sent, a transient is set in the WordPress object cache for the duration of the configured cooldown period. Any 404 that fires during that window skips the email send entirely. The next email goes out after the cooldown expires.
+
+**Is this plugin GDPR-friendly?**
+
+You can disable IP logging with the **Log IP** checkbox under General settings. When disabled, the IP column in all log entries records `N/A`. No IP data is stored or emailed.
+
+---
+
+## Support
+
+Open an issue on [GitHub](https://github.com/kunalnagar/custom-404-pro/issues). The WordPress.org support forum is not monitored.
+
+## Rate & Review
+
+If the plugin is useful to you, a [rating on WordPress.org](https://wordpress.org/plugins/custom-404-pro/) or a GitHub star goes a long way.
+
+## Donate
+
+Like the plugin? [Buy me a coffee via PayPal](https://www.paypal.me/kunalnagar/10).
+
+---
+
+## Changelog
+
+See [WordPress.org changelog](https://wordpress.org/plugins/custom-404-pro/changelog/) for the full history.
+
+### 3.12.9
+- Add email notification cooldown to prevent inbox flooding. Configurable from 15 minutes to 24 hours (default: 1 hour).
+
+### 3.12.8
+- Fix IP logging toggle not persisting correctly due to positional row access.
+
+### 3.12.7
+- Fix WPML/Polylang settings overwriting each other when using per-language domains.
+
+### 3.12.6
+- Add `load_plugin_textdomain` support for translations.
+
+### 3.12.5
+- Add Polylang and WPML support for the 404 redirect page.
+
+### 3.12.4
+- Enforce full WordPress coding standards: PHPDoc comments, input sanitization, file naming convention.
+
+### 3.12.3
+- Improve codebase to meet WordPress coding standards.
+
+### 3.12.2
+- Fix PHP 8.2+ dynamic property deprecation warnings.
+
+### 3.12.1
+- Security: Remediate SQL injection and CSRF vulnerabilities (CVE-2025-9947).
+- Update tested up to WordPress 6.9.4.
+
+### 3.12.0
+- Support WordPress 6.6.
+
+### 3.3.0
+- Add Multisite support.
+
+### 3.2.0
+- Export logs as CSV.
+- Validate URL format when URL redirect mode is selected.
+
+### 3.1.0
+- IP logging is now optional.
+
+### 3.0.0
+- Complete rewrite with a new logging mechanism and improved architecture.
+
+---
+
+## License
+
+[GPLv2 or later](LICENSE.txt)

--- a/admin/class-adminclass.php
+++ b/admin/class-adminclass.php
@@ -138,7 +138,7 @@ class AdminClass {
 			$allowed_codes             = array( 301, 302, 307, 308 );
 			$field_redirect_error_code = in_array( $field_redirect_error_code, $allowed_codes, true ) ? $field_redirect_error_code : 302;
 			$allowed_cooldowns         = array( 900, 1800, 3600, 21600, 86400 );
-			$raw_cooldown              = isset( $_POST['email_cooldown'] ) ? absint( $_POST['email_cooldown'] ) : HOUR_IN_SECONDS;
+			$raw_cooldown              = isset( $_POST['email_cooldown'] ) ? absint( wp_unslash( $_POST['email_cooldown'] ) ) : HOUR_IN_SECONDS;
 			$field_email_cooldown      = in_array( $raw_cooldown, $allowed_cooldowns, true ) ? $raw_cooldown : HOUR_IN_SECONDS;
 			$this->helpers->update_settings(
 				array(
@@ -238,6 +238,7 @@ class AdminClass {
 	/**
 	 * Logs a 404 event and optionally sends a notification email.
 	 *
+	 * @since 3.13.0 Added $email_cooldown parameter.
 	 * @param bool $is_email        Whether to send a notification email.
 	 * @param int  $email_cooldown  Cooldown period in seconds between notification emails.
 	 */
@@ -272,6 +273,7 @@ class AdminClass {
 	 * Returns true when a cooldown transient is set, meaning an email was already
 	 * sent within the configured cooldown window and another should not be sent yet.
 	 *
+	 * @since 3.13.0
 	 * @return bool True if cooldown is active, false if an email may be sent.
 	 */
 	public function is_email_on_cooldown(): bool {

--- a/admin/class-adminclass.php
+++ b/admin/class-adminclass.php
@@ -201,12 +201,14 @@ class AdminClass {
 				$page_id = $this->resolve_multilingual_page_id( (int) ( $options['mode_page'] ?? 0 ) );
 				$page    = get_post( $page_id );
 				if ( $page ) {
-					wp_safe_redirect( $page->guid, (int) ( $options['redirect_error_code'] ?? 302 ) );
-					exit;
+					if ( wp_safe_redirect( $page->guid, (int) ( $options['redirect_error_code'] ?? 302 ) ) ) {
+						exit;
+					}
 				}
 			} elseif ( 'url' === ( $options['mode'] ?? '' ) ) {
-				wp_safe_redirect( $options['mode_url'] ?? '', (int) ( $options['redirect_error_code'] ?? 302 ) );
-				exit;
+				if ( wp_safe_redirect( $options['mode_url'] ?? '', (int) ( $options['redirect_error_code'] ?? 302 ) ) ) {
+					exit;
+				}
 			}
 		}
 	}

--- a/admin/class-adminclass.php
+++ b/admin/class-adminclass.php
@@ -137,12 +137,16 @@ class AdminClass {
 			$field_redirect_error_code = isset( $_POST['redirect_error_code'] ) ? absint( wp_unslash( $_POST['redirect_error_code'] ) ) : 302;
 			$allowed_codes             = array( 301, 302, 307, 308 );
 			$field_redirect_error_code = in_array( $field_redirect_error_code, $allowed_codes, true ) ? $field_redirect_error_code : 302;
+			$allowed_cooldowns         = array( 900, 1800, 3600, 21600, 86400 );
+			$raw_cooldown              = isset( $_POST['email_cooldown'] ) ? absint( $_POST['email_cooldown'] ) : HOUR_IN_SECONDS;
+			$field_email_cooldown      = in_array( $raw_cooldown, $allowed_cooldowns, true ) ? $raw_cooldown : HOUR_IN_SECONDS;
 			$this->helpers->update_settings(
 				array(
 					'send_email'          => ( 'on' === $send_email ),
 					'logging_enabled'     => ( 'enabled' === $logging_enabled ),
 					'log_ip'              => ( 'on' === $log_ip ),
 					'redirect_error_code' => $field_redirect_error_code,
+					'email_cooldown'      => $field_email_cooldown,
 				)
 			);
 			$message = rawurlencode( 'Saved!' );
@@ -190,7 +194,8 @@ class AdminClass {
 		if ( is_404() ) {
 			$options = $this->helpers->get_settings();
 			if ( ! empty( $options['logging_enabled'] ) ) {
-				self::custom_404_pro_log( $options['send_email'] ?? '' );
+				$email_cooldown = isset( $options['email_cooldown'] ) ? (int) $options['email_cooldown'] : HOUR_IN_SECONDS;
+				self::custom_404_pro_log( $options['send_email'] ?? '', $email_cooldown );
 			}
 			if ( 'page' === ( $options['mode'] ?? '' ) ) {
 				$page_id = $this->resolve_multilingual_page_id( (int) ( $options['mode_page'] ?? 0 ) );
@@ -233,9 +238,10 @@ class AdminClass {
 	/**
 	 * Logs a 404 event and optionally sends a notification email.
 	 *
-	 * @param bool $is_email Whether to send a notification email.
+	 * @param bool $is_email        Whether to send a notification email.
+	 * @param int  $email_cooldown  Cooldown period in seconds between notification emails.
 	 */
-	private function custom_404_pro_log( $is_email ) {
+	private function custom_404_pro_log( $is_email, $email_cooldown = HOUR_IN_SECONDS ) {
 		global $wpdb;
 		if ( empty( $this->helpers->get_setting( 'log_ip' ) ) ) {
 			$ip = 'N/A';
@@ -254,9 +260,22 @@ class AdminClass {
 		$user_agent = isset( $_SERVER['HTTP_USER_AGENT'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) : '';
 		$sql_save   = $wpdb->prepare( 'INSERT INTO ' . $wpdb->prefix . $this->helpers->table_logs . ' (ip, path, referer, user_agent) VALUES (%s, %s, %s, %s)', $ip, $path, $referer, $user_agent ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		$wpdb->query( $sql_save ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
-		if ( ! empty( $is_email ) ) {
+		if ( ! empty( $is_email ) && ! $this->is_email_on_cooldown() ) {
 			self::custom_404_pro_send_mail( $ip, $path, $referer, $user_agent );
+			set_transient( 'custom_404_pro_email_cooldown', true, $email_cooldown );
 		}
+	}
+
+	/**
+	 * Checks whether the email notification cooldown is currently active.
+	 *
+	 * Returns true when a cooldown transient is set, meaning an email was already
+	 * sent within the configured cooldown window and another should not be sent yet.
+	 *
+	 * @return bool True if cooldown is active, false if an email may be sent.
+	 */
+	public function is_email_on_cooldown(): bool {
+		return (bool) get_transient( 'custom_404_pro_email_cooldown' );
 	}
 
 	/**

--- a/admin/class-helpers.php
+++ b/admin/class-helpers.php
@@ -66,6 +66,7 @@ class Helpers {
 			'logging_enabled'     => false,
 			'redirect_error_code' => 302,
 			'log_ip'              => true,
+			'email_cooldown'      => 3600,
 		);
 	}
 

--- a/admin/views/settings-general.php
+++ b/admin/views/settings-general.php
@@ -11,6 +11,7 @@ $send_email          = $options['send_email'] ?? false;
 $logging_enabled     = $options['logging_enabled'] ?? false;
 $redirect_error_code = isset( $options['redirect_error_code'] ) ? (int) $options['redirect_error_code'] : 302;
 $log_ip              = $options['log_ip'] ?? true;
+$email_cooldown      = isset( $options['email_cooldown'] ) ? (int) $options['email_cooldown'] : 3600;
 ?>
 <div class="wrap">
 	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
@@ -22,6 +23,21 @@ $log_ip              = $options['log_ip'] ?? true;
 					<input type="checkbox" id="c4p_log_email" name="send_email" <?php echo (bool) $send_email ? 'checked' : ''; ?> />
 					<p class="description">
 						If you check this, <b>and logging is enabled</b>, an email will be sent on every error log on the admin's email account. If you're just starting out, it is recommended you uncheck this. Enable it based on your error volume to avoid flooding of your email inbox.
+					</p>
+				</td>
+			</tr>
+			<tr>
+				<th>Email Notification Cooldown</th>
+				<td>
+					<select name="email_cooldown">
+						<option value="900" <?php echo 900 === $email_cooldown ? 'selected' : ''; ?>>15 minutes</option>
+						<option value="1800" <?php echo 1800 === $email_cooldown ? 'selected' : ''; ?>>30 minutes</option>
+						<option value="3600" <?php echo 3600 === $email_cooldown ? 'selected' : ''; ?>>1 hour</option>
+						<option value="21600" <?php echo 21600 === $email_cooldown ? 'selected' : ''; ?>>6 hours</option>
+						<option value="86400" <?php echo 86400 === $email_cooldown ? 'selected' : ''; ?>>24 hours</option>
+					</select>
+					<p class="description">
+						After a notification email is sent, no further emails will be sent until this cooldown period expires. This prevents your inbox from being flooded during high-traffic or bot-targeted events.
 					</p>
 				</td>
 			</tr>

--- a/admin/views/settings-general.php
+++ b/admin/views/settings-general.php
@@ -37,7 +37,7 @@ $email_cooldown      = isset( $options['email_cooldown'] ) ? (int) $options['ema
 						<option value="86400" <?php echo 86400 === $email_cooldown ? 'selected' : ''; ?>>24 hours</option>
 					</select>
 					<p class="description">
-						After a notification email is sent, no further emails will be sent until this cooldown period expires. This prevents your inbox from being flooded during high-traffic or bot-targeted events.
+						Only applies when <b>Email</b> is enabled. After a notification email is sent, no further emails will be sent for the selected duration. This prevents inbox flooding during bot crawls or traffic spikes.
 					</p>
 				</td>
 			</tr>

--- a/custom-404-pro.php
+++ b/custom-404-pro.php
@@ -3,7 +3,7 @@
  * Plugin Name: Custom 404 Pro
  * Plugin URI: https://wordpress.org/plugins/custom-404-pro/
  * Description: Override the default 404 page with any page or a custom URL from the Admin Panel.
- * Version: 3.12.9
+ * Version: 3.13.0
  * Author: Kunal Nagar
  * Author URI: https://www.kunalnagar.in
  * License: GPL-2.0+
@@ -18,7 +18,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'CUSTOM_404_PRO_VERSION', '3.12.9' );
+define( 'CUSTOM_404_PRO_VERSION', '3.13.0' );
 
 /**
  * Runs on plugin activation.

--- a/includes/class-uninstallclass.php
+++ b/includes/class-uninstallclass.php
@@ -39,9 +39,10 @@ class UninstallClass {
 	private static function cleanup_site() {
 		global $wpdb;
 
-		// Remove plugin settings and migration marker from wp_options.
+		// Remove plugin settings, migration marker, and transients from wp_options.
 		delete_option( Helpers::OPTION_KEY );
 		delete_option( 'custom_404_pro_db_version' );
+		delete_transient( 'custom_404_pro_email_cooldown' );
 
 		// Drop the logs table.
 		$table_logs = $wpdb->prefix . 'custom_404_pro_logs';

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.me/kunalnagar88/10
 Tags: 404, redirect, custom 404, error page, logging
 Requires at least: 3.0.1
 Tested up to: 6.9.4
-Stable tag: 3.12.9
+Stable tag: 3.13.0
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -82,9 +82,11 @@ Please open an issue on [GitHub](https://github.com/kunalnagar/custom-404-pro/is
 
 == Changelog ==
 
+= 3.13.0 =
+* Add configurable email notification cooldown to prevent inbox flooding on high 404 traffic (15 min / 30 min / 1 hr / 6 hr / 24 hr)
+
 = 3.12.9 =
 * Migrate plugin settings from a custom database table to native wp_options for better compatibility and performance
-* Add configurable email notification cooldown to prevent inbox flooding on high 404 traffic (15 min / 30 min / 1 hr / 6 hr / 24 hr)
 
 = 3.12.8 =
 * Fix IP logging toggle not persisting correctly due to positional row access

--- a/readme.txt
+++ b/readme.txt
@@ -84,6 +84,7 @@ Please open an issue on [GitHub](https://github.com/kunalnagar/custom-404-pro/is
 
 = 3.12.9 =
 * Migrate plugin settings from a custom database table to native wp_options for better compatibility and performance
+* Add configurable email notification cooldown to prevent inbox flooding on high 404 traffic (15 min / 30 min / 1 hr / 6 hr / 24 hr)
 
 = 3.12.8 =
 * Fix IP logging toggle not persisting correctly due to positional row access

--- a/tests/AdminClassTest.php
+++ b/tests/AdminClassTest.php
@@ -35,11 +35,12 @@ class AdminClassTest extends TestCase {
 	}
 
 	/**
-	 * Resets multilingual stubs and filter registry before each test.
+	 * Resets multilingual stubs, filter registry, and transient store before each test.
 	 */
 	protected function setUp(): void {
 		parent::setUp();
 		$GLOBALS['_test_filters']        = array();
+		$GLOBALS['_test_transients']     = array();
 		$GLOBALS['_pll_get_post_return'] = false;
 		unset( $GLOBALS['_pll_current_language'] );
 		unset( $GLOBALS['_pll_default_language'] );
@@ -147,5 +148,36 @@ class AdminClassTest extends TestCase {
 		$GLOBALS['_pll_get_post_return']  = false; // pll_get_post returns false → no translation.
 		$admin = new AdminClass();
 		$this->assertSame( 20, $this->normalize( $admin, 20 ) );
+	}
+
+	// ------------------------------------------------------------------
+	// is_email_on_cooldown
+	// ------------------------------------------------------------------
+
+	/**
+	 * Asserts that is_email_on_cooldown() returns false when no transient has been set.
+	 */
+	public function test_is_email_on_cooldown_returns_false_when_no_transient_set() {
+		$admin = new AdminClass();
+		$this->assertFalse( $admin->is_email_on_cooldown() );
+	}
+
+	/**
+	 * Asserts that is_email_on_cooldown() returns true when the cooldown transient is set.
+	 */
+	public function test_is_email_on_cooldown_returns_true_when_transient_is_set() {
+		set_transient( 'custom_404_pro_email_cooldown', true, HOUR_IN_SECONDS );
+		$admin = new AdminClass();
+		$this->assertTrue( $admin->is_email_on_cooldown() );
+	}
+
+	/**
+	 * Asserts that is_email_on_cooldown() returns false after the cooldown transient is deleted.
+	 */
+	public function test_is_email_on_cooldown_returns_false_after_transient_deleted() {
+		set_transient( 'custom_404_pro_email_cooldown', true, HOUR_IN_SECONDS );
+		delete_transient( 'custom_404_pro_email_cooldown' );
+		$admin = new AdminClass();
+		$this->assertFalse( $admin->is_email_on_cooldown() );
 	}
 }

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -60,7 +60,7 @@ class HelpersTest extends TestCase {
 	 */
 	public function test_defaults_contains_all_required_keys() {
 		$helpers  = new Helpers();
-		$required = array( 'mode', 'mode_page', 'mode_url', 'send_email', 'logging_enabled', 'redirect_error_code', 'log_ip' );
+		$required = array( 'mode', 'mode_page', 'mode_url', 'send_email', 'logging_enabled', 'redirect_error_code', 'log_ip', 'email_cooldown' );
 		foreach ( $required as $key ) {
 			$this->assertArrayHasKey( $key, $helpers->defaults(), "defaults() should contain key '{$key}'." );
 		}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -14,6 +14,18 @@ $GLOBALS['_test_filters']                 = array();
 $GLOBALS['_test_actions']                 = array();
 $GLOBALS['_load_plugin_textdomain_calls'] = array();
 $GLOBALS['_test_options']                 = array();
+$GLOBALS['_test_transients']              = array();
+
+// WordPress time constants.
+if ( ! defined( 'MINUTE_IN_SECONDS' ) ) {
+	define( 'MINUTE_IN_SECONDS', 60 );
+}
+if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
+	define( 'HOUR_IN_SECONDS', 3600 );
+}
+if ( ! defined( 'DAY_IN_SECONDS' ) ) {
+	define( 'DAY_IN_SECONDS', 86400 );
+}
 
 /**
  * Stub for WordPress apply_filters().
@@ -197,6 +209,46 @@ function add_option( string $option, $value ) {
  */
 function delete_option( string $option ): bool {
 	unset( $GLOBALS['_test_options'][ $option ] );
+	return true;
+}
+
+/**
+ * Stub for WordPress get_transient().
+ *
+ * Returns the value stored in the test transient registry, or false if not set.
+ *
+ * @param string $transient Transient name.
+ * @return mixed Stored value, or false if not set.
+ */
+function get_transient( string $transient ) {
+	return $GLOBALS['_test_transients'][ $transient ] ?? false;
+}
+
+/**
+ * Stub for WordPress set_transient().
+ *
+ * Stores a value in the test transient registry.
+ *
+ * @param string $transient  Transient name.
+ * @param mixed  $value      Value to store.
+ * @param int    $expiration Ignored in unit tests.
+ * @return bool Always true.
+ */
+function set_transient( string $transient, $value, int $expiration = 0 ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	$GLOBALS['_test_transients'][ $transient ] = $value;
+	return true;
+}
+
+/**
+ * Stub for WordPress delete_transient().
+ *
+ * Removes a value from the test transient registry.
+ *
+ * @param string $transient Transient name.
+ * @return bool Always true.
+ */
+function delete_transient( string $transient ): bool {
+	unset( $GLOBALS['_test_transients'][ $transient ] );
 	return true;
 }
 

--- a/tests/integration/RedirectTest.php
+++ b/tests/integration/RedirectTest.php
@@ -223,10 +223,14 @@ class C404P_Integration_RedirectTest extends WP_UnitTestCase {
 	 * The cooldown transient should be set after a notification email is sent.
 	 */
 	public function test_email_cooldown_transient_is_set_after_notification_sent() {
-		$this->helpers->update_option( 'logging_enabled', '1' );
-		$this->helpers->update_option( 'send_email', '1' );
-		$this->helpers->update_option( 'mode', 'url' );
-		$this->helpers->update_option( 'mode_url', 'https://example.com' );
+		$this->helpers->update_settings(
+			array(
+				'logging_enabled' => true,
+				'send_email'      => true,
+				'mode'            => 'url',
+				'mode_url'        => 'https://example.com',
+			)
+		);
 
 		$this->assertFalse(
 			get_transient( 'custom_404_pro_email_cooldown' ),
@@ -247,10 +251,14 @@ class C404P_Integration_RedirectTest extends WP_UnitTestCase {
 	 * Uses a wp_mail filter to count how many times wp_mail() is invoked.
 	 */
 	public function test_email_not_sent_during_active_cooldown() {
-		$this->helpers->update_option( 'logging_enabled', '1' );
-		$this->helpers->update_option( 'send_email', '1' );
-		$this->helpers->update_option( 'mode', 'url' );
-		$this->helpers->update_option( 'mode_url', 'https://example.com' );
+		$this->helpers->update_settings(
+			array(
+				'logging_enabled' => true,
+				'send_email'      => true,
+				'mode'            => 'url',
+				'mode_url'        => 'https://example.com',
+			)
+		);
 
 		// Pre-set the cooldown transient to simulate a recent send.
 		set_transient( 'custom_404_pro_email_cooldown', true, HOUR_IN_SECONDS );
@@ -273,10 +281,14 @@ class C404P_Integration_RedirectTest extends WP_UnitTestCase {
 	 * Exactly one email should be sent on the first 404, and none on the second.
 	 */
 	public function test_only_one_email_sent_across_two_consecutive_404s() {
-		$this->helpers->update_option( 'logging_enabled', '1' );
-		$this->helpers->update_option( 'send_email', '1' );
-		$this->helpers->update_option( 'mode', 'url' );
-		$this->helpers->update_option( 'mode_url', 'https://example.com' );
+		$this->helpers->update_settings(
+			array(
+				'logging_enabled' => true,
+				'send_email'      => true,
+				'mode'            => 'url',
+				'mode_url'        => 'https://example.com',
+			)
+		);
 
 		$mail_count = 0;
 		$counter    = function ( $args ) use ( &$mail_count ) {

--- a/tests/integration/RedirectTest.php
+++ b/tests/integration/RedirectTest.php
@@ -214,4 +214,85 @@ class C404P_Integration_RedirectTest extends WP_UnitTestCase {
 		$logs = $this->helpers->get_logs();
 		$this->assertEmpty( $logs, 'No log entry should be created when logging is disabled.' );
 	}
+
+	// -------------------------------------------------------------------------
+	// Email cooldown tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * The cooldown transient should be set after a notification email is sent.
+	 */
+	public function test_email_cooldown_transient_is_set_after_notification_sent() {
+		$this->helpers->update_option( 'logging_enabled', '1' );
+		$this->helpers->update_option( 'send_email', '1' );
+		$this->helpers->update_option( 'mode', 'url' );
+		$this->helpers->update_option( 'mode_url', 'https://example.com' );
+
+		$this->assertFalse(
+			get_transient( 'custom_404_pro_email_cooldown' ),
+			'Cooldown transient should not exist before the first 404.'
+		);
+
+		$this->admin->custom_404_pro_redirect();
+
+		$this->assertNotFalse(
+			get_transient( 'custom_404_pro_email_cooldown' ),
+			'Cooldown transient should be set after an email notification is sent.'
+		);
+	}
+
+	/**
+	 * No email should be sent when the cooldown transient is already active.
+	 *
+	 * Uses a wp_mail filter to count how many times wp_mail() is invoked.
+	 */
+	public function test_email_not_sent_during_active_cooldown() {
+		$this->helpers->update_option( 'logging_enabled', '1' );
+		$this->helpers->update_option( 'send_email', '1' );
+		$this->helpers->update_option( 'mode', 'url' );
+		$this->helpers->update_option( 'mode_url', 'https://example.com' );
+
+		// Pre-set the cooldown transient to simulate a recent send.
+		set_transient( 'custom_404_pro_email_cooldown', true, HOUR_IN_SECONDS );
+
+		$mail_count = 0;
+		$counter    = function ( $args ) use ( &$mail_count ) {
+			++$mail_count;
+			return $args;
+		};
+		add_filter( 'wp_mail', $counter );
+
+		$this->admin->custom_404_pro_redirect();
+
+		remove_filter( 'wp_mail', $counter );
+
+		$this->assertSame( 0, $mail_count, 'No email should be sent while the cooldown transient is active.' );
+	}
+
+	/**
+	 * Exactly one email should be sent on the first 404, and none on the second.
+	 */
+	public function test_only_one_email_sent_across_two_consecutive_404s() {
+		$this->helpers->update_option( 'logging_enabled', '1' );
+		$this->helpers->update_option( 'send_email', '1' );
+		$this->helpers->update_option( 'mode', 'url' );
+		$this->helpers->update_option( 'mode_url', 'https://example.com' );
+
+		$mail_count = 0;
+		$counter    = function ( $args ) use ( &$mail_count ) {
+			++$mail_count;
+			return $args;
+		};
+		add_filter( 'wp_mail', $counter );
+
+		// First 404 — should trigger an email and set the transient.
+		$this->admin->custom_404_pro_redirect();
+
+		// Second 404 — transient is now active, email should be suppressed.
+		$this->admin->custom_404_pro_redirect();
+
+		remove_filter( 'wp_mail', $counter );
+
+		$this->assertSame( 1, $mail_count, 'Exactly one email should be sent across two consecutive 404s.' );
+	}
 }


### PR DESCRIPTION
Closes #98

## What

Adds a configurable transient-based cooldown that prevents repeated admin email notifications from firing on every single 404. After the first email is sent, the plugin stays quiet until the cooldown period expires.

## Why

Without this, a bot crawl, a broken redirect loop, or a traffic spike can send thousands of emails to the site admin in minutes — effectively a self-inflicted mail bomb. This was flagged as a critical operational risk in the plugin improvement review.

> **Note:** This branch has been rebased onto `refactor/migrate-options-to-wp-options` (#101). It must be merged after that PR lands, otherwise this branch should be re-targeted to `master` once the refactor is merged.

## Changes

### Core logic
- **`AdminClass::is_email_on_cooldown()`** — new public method; returns `true` when the `custom_404_pro_email_cooldown` transient is set
- **`AdminClass::custom_404_pro_log()`** — accepts a `$email_cooldown` parameter; wraps the send behind `is_email_on_cooldown()` and sets the transient after a successful send
- **`AdminClass::custom_404_pro_redirect()`** — reads `email_cooldown` from settings via `get_settings()` and passes it down to `custom_404_pro_log()`
- **`AdminClass::form_settings_general()`** — validates and saves `email_cooldown` via `update_settings()` (allowlist: 900, 1800, 3600, 21600, 86400); falls back to `HOUR_IN_SECONDS`

### Settings
- **`Helpers::defaults()`** — `email_cooldown` seeded at `3600` alongside all other defaults in `wp_options`
- **`settings-general.php`** — new "Email Notification Cooldown" `<select>` row with options: 15 min / 30 min / 1 hour / 6 hours / 24 hours

### Tests
- **`tests/bootstrap.php`** — time constants (`HOUR_IN_SECONDS` etc.) + `get_transient()`, `set_transient()`, `delete_transient()` stubs alongside the wp_options stubs
- **`tests/AdminClassTest.php`** — 3 unit tests for `is_email_on_cooldown()`
- **`tests/HelpersTest.php`** — `email_cooldown` added to required defaults keys assertion
- **`tests/integration/RedirectTest.php`** — 3 integration tests: transient set after send, no email during active cooldown, exactly one email across two 404s

### Documentation
- **`README.md`** — full rewrite documenting all plugin features, settings reference tables, FAQ, and the new cooldown feature

## Test plan

- [ ] Unit tests pass: `composer test`
- [ ] Integration tests pass: `composer test:integration`
- [ ] Activate plugin, enable logging + email, trigger a 404 twice in quick succession — confirm only one email arrives
- [ ] Change cooldown to 15 minutes in General settings, save, confirm value persists on page reload
- [ ] Fresh install: confirm `email_cooldown` defaults to `3600` in `wp_options`