### PR TITLE
refactor: replace custom options table with wp_options

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,0 +1,14 @@
+{
+  "core": "WordPress/WordPress#6.7",
+  "phpVersion": "8.1",
+  "plugins": [
+    "."
+  ],
+  "testsEnvironment": false,
+  "config": {
+    "WP_DEBUG": true,
+    "WP_DEBUG_LOG": true,
+    "WP_DEBUG_DISPLAY": false,
+    "SCRIPT_DEBUG": true
+  }
+}

--- a/admin/class-adminclass.php
+++ b/admin/class-adminclass.php
@@ -114,13 +114,14 @@ class AdminClass {
 	 */
 	public function form_settings_global_redirect() {
 		$nonce = isset( $_POST['form-settings-global-redirect'] ) ? sanitize_text_field( wp_unslash( $_POST['form-settings-global-redirect'] ) ) : '';
-		if ( wp_verify_nonce( $nonce, 'form-settings-global-redirect' ) && check_admin_referer( 'form-settings-global-redirect', 'form-settings-global-redirect' ) && current_user_can( 'manage_options' ) ) {
+		if ( check_admin_referer( 'form-settings-global-redirect', 'form-settings-global-redirect' ) && current_user_can( 'manage_options' ) ) {
 			$mode = isset( $_POST['mode'] ) ? sanitize_text_field( wp_unslash( $_POST['mode'] ) ) : '';
 			$page = isset( $_POST['mode_page'] ) ? sanitize_text_field( wp_unslash( $_POST['mode_page'] ) ) : '';
 			$url  = isset( $_POST['mode_url'] ) ? sanitize_text_field( wp_unslash( $_POST['mode_url'] ) ) : '';
 			self::update_mode( $mode, $page, $url );
 			$message = rawurlencode( 'Saved!' );
 			wp_safe_redirect( admin_url( 'admin.php?page=c4p-settings&tab=global-redirect&c4pmessage=' . $message . '&c4pmessageType=success' ) );
+			exit;
 		}
 	}
 
@@ -129,7 +130,7 @@ class AdminClass {
 	 */
 	public function form_settings_general() {
 		$nonce = isset( $_POST['form-settings-general'] ) ? sanitize_text_field( wp_unslash( $_POST['form-settings-general'] ) ) : '';
-		if ( wp_verify_nonce( $nonce, 'form-settings-general' ) && check_admin_referer( 'form-settings-general', 'form-settings-general' ) && current_user_can( 'manage_options' ) ) {
+		if ( check_admin_referer( 'form-settings-general', 'form-settings-general' ) && current_user_can( 'manage_options' ) ) {
 			$send_email                = isset( $_POST['send_email'] ) ? sanitize_text_field( wp_unslash( $_POST['send_email'] ) ) : '';
 			$logging_enabled           = isset( $_POST['logging_enabled'] ) ? sanitize_text_field( wp_unslash( $_POST['logging_enabled'] ) ) : '';
 			$log_ip                    = isset( $_POST['log_ip'] ) ? sanitize_text_field( wp_unslash( $_POST['log_ip'] ) ) : '';
@@ -146,6 +147,7 @@ class AdminClass {
 			);
 			$message = rawurlencode( 'Saved!' );
 			wp_safe_redirect( admin_url( 'admin.php?page=c4p-settings&tab=general&c4pmessage=' . $message . '&c4pmessageType=success' ) );
+			exit;
 		}
 	}
 
@@ -163,14 +165,17 @@ class AdminClass {
 						$this->helpers->delete_logs( $path );
 						$message = rawurlencode( 'Log(s) successfully deleted!' );
 						wp_safe_redirect( admin_url( 'admin.php?page=c4p-main&c4pmessage=' . $message . '&c4pmessageType=success' ) );
+						exit;
 					} else {
 						$message = rawurlencode( 'Please select a few logs to delete and try again.' );
 						wp_safe_redirect( admin_url( 'admin.php?page=c4p-main&c4pmessage=' . $message . '&c4pmessageType=warning' ) );
+						exit;
 					}
 				} elseif ( 'c4p-logs--delete-all' === $action && wp_verify_nonce( $nonce, 'bulk-logs' ) ) {
 					$this->helpers->delete_logs( 'all' );
 					$message = rawurlencode( 'All Logs successfully deleted!' );
 					wp_safe_redirect( admin_url( 'admin.php?page=c4p-main&c4pmessage=' . $message . '&c4pmessageType=success' ) );
+					exit;
 				} elseif ( 'c4p-logs--export-csv' === $action && wp_verify_nonce( $nonce, 'bulk-logs' ) ) {
 					$this->helpers->export_logs_csv();
 				}
@@ -190,9 +195,13 @@ class AdminClass {
 			if ( 'page' === ( $options['mode'] ?? '' ) ) {
 				$page_id = $this->resolve_multilingual_page_id( (int) ( $options['mode_page'] ?? 0 ) );
 				$page    = get_post( $page_id );
-				wp_safe_redirect( $page->guid, (int) ( $options['redirect_error_code'] ?? 302 ) );
+				if ( $page ) {
+					wp_safe_redirect( $page->guid, (int) ( $options['redirect_error_code'] ?? 302 ) );
+					exit;
+				}
 			} elseif ( 'url' === ( $options['mode'] ?? '' ) ) {
 				wp_safe_redirect( $options['mode_url'] ?? '', (int) ( $options['redirect_error_code'] ?? 302 ) );
+				exit;
 			}
 		}
 	}

--- a/admin/class-adminclass.php
+++ b/admin/class-adminclass.php
@@ -133,14 +133,17 @@ class AdminClass {
 			$send_email                = isset( $_POST['send_email'] ) ? sanitize_text_field( wp_unslash( $_POST['send_email'] ) ) : '';
 			$logging_enabled           = isset( $_POST['logging_enabled'] ) ? sanitize_text_field( wp_unslash( $_POST['logging_enabled'] ) ) : '';
 			$log_ip                    = isset( $_POST['log_ip'] ) ? sanitize_text_field( wp_unslash( $_POST['log_ip'] ) ) : '';
-			$field_redirect_error_code = isset( $_POST['redirect_error_code'] ) ? sanitize_text_field( wp_unslash( $_POST['redirect_error_code'] ) ) : '';
-			$field_send_email          = ( 'on' === $send_email );
-			$field_logging_enabled     = ( 'enabled' === $logging_enabled );
-			$field_log_ip              = ( 'on' === $log_ip );
-			$this->helpers->update_option( 'send_email', $field_send_email );
-			$this->helpers->update_option( 'logging_enabled', $field_logging_enabled );
-			$this->helpers->update_option( 'redirect_error_code', $field_redirect_error_code );
-			$this->helpers->upsert_option( 'log_ip', $field_log_ip );
+			$field_redirect_error_code = isset( $_POST['redirect_error_code'] ) ? absint( wp_unslash( $_POST['redirect_error_code'] ) ) : 302;
+			$allowed_codes             = array( 301, 302, 307, 308 );
+			$field_redirect_error_code = in_array( $field_redirect_error_code, $allowed_codes, true ) ? $field_redirect_error_code : 302;
+			$this->helpers->update_settings(
+				array(
+					'send_email'          => ( 'on' === $send_email ),
+					'logging_enabled'     => ( 'enabled' === $logging_enabled ),
+					'log_ip'              => ( 'on' === $log_ip ),
+					'redirect_error_code' => $field_redirect_error_code,
+				)
+			);
 			$message = rawurlencode( 'Saved!' );
 			wp_safe_redirect( admin_url( 'admin.php?page=c4p-settings&tab=general&c4pmessage=' . $message . '&c4pmessageType=success' ) );
 		}
@@ -179,13 +182,8 @@ class AdminClass {
 	 * Handles 404 detection and redirects.
 	 */
 	public function custom_404_pro_redirect() {
-		global $wpdb;
 		if ( is_404() ) {
-			$rows    = $wpdb->get_results( 'SELECT name, value FROM ' . $wpdb->prefix . $this->helpers->table_options ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-			$options = array();
-			foreach ( $rows as $row ) {
-				$options[ $row->name ] = $row->value;
-			}
+			$options = $this->helpers->get_settings();
 			if ( ! empty( $options['logging_enabled'] ) ) {
 				self::custom_404_pro_log( $options['send_email'] ?? '' );
 			}
@@ -230,10 +228,7 @@ class AdminClass {
 	 */
 	private function custom_404_pro_log( $is_email ) {
 		global $wpdb;
-		if ( ! $this->helpers->is_option( 'log_ip' ) ) {
-			$this->helpers->insert_option( 'log_ip', true );
-		}
-		if ( empty( $this->helpers->get_option( 'log_ip' ) ) ) {
+		if ( empty( $this->helpers->get_setting( 'log_ip' ) ) ) {
 			$ip = 'N/A';
 		} elseif ( ! empty( $_SERVER['HTTP_CLIENT_IP'] ) ) {
 			$ip = sanitize_text_field( wp_unslash( $_SERVER['HTTP_CLIENT_IP'] ) );
@@ -344,29 +339,35 @@ class AdminClass {
 	 */
 	private function update_mode( $mode, $page, $url ) {
 		if ( current_user_can( 'manage_options' ) ) {
-			$mode_val      = '';
-			$mode_page_val = '';
-			$mode_url_val  = '';
 			switch ( $mode ) {
 				case 'page':
-					$mode_val      = 'page';
-					$mode_page_val = (string) $this->normalize_page_id_to_default_language( (int) $page );
-					$mode_url_val  = '';
+					$this->helpers->update_settings(
+						array(
+							'mode'      => 'page',
+							'mode_page' => (string) $this->normalize_page_id_to_default_language( (int) $page ),
+							'mode_url'  => '',
+						)
+					);
 					break;
 				case 'url':
-					$mode_val      = 'url';
-					$mode_page_val = '';
-					$mode_url_val  = $url;
+					$this->helpers->update_settings(
+						array(
+							'mode'      => 'url',
+							'mode_page' => '',
+							'mode_url'  => $url,
+						)
+					);
 					break;
-				case '':
-					$mode_val      = '';
-					$mode_page_val = '';
-					$mode_url_val  = '';
+				default:
+					$this->helpers->update_settings(
+						array(
+							'mode'      => '',
+							'mode_page' => '',
+							'mode_url'  => '',
+						)
+					);
 					break;
 			}
-			$this->helpers->update_option( 'mode', $mode_val );
-			$this->helpers->update_option( 'mode_page', $mode_page_val );
-			$this->helpers->update_option( 'mode_url', $mode_url_val );
 		}
 	}
 }

--- a/admin/class-helpers.php
+++ b/admin/class-helpers.php
@@ -18,13 +18,6 @@ class Helpers {
 	private static $instance;
 
 	/**
-	 * Options table name (without prefix).
-	 *
-	 * @var string
-	 */
-	public $table_options;
-
-	/**
 	 * Logs table name (without prefix).
 	 *
 	 * @var string
@@ -32,11 +25,11 @@ class Helpers {
 	public $table_logs;
 
 	/**
-	 * Default option values.
+	 * wp_options key used to store all plugin settings.
 	 *
-	 * @var array
+	 * @var string
 	 */
-	public $options_defaults;
+	const OPTION_KEY = 'custom_404_pro_settings';
 
 	/**
 	 * Returns the singleton instance of this class.
@@ -55,25 +48,62 @@ class Helpers {
 	 * Constructor.
 	 */
 	public function __construct() {
-		global $wpdb;
-		$this->table_options    = 'custom_404_pro_options';
-		$this->table_logs       = 'custom_404_pro_logs';
-		$this->options_defaults = array();
-		$options_defaults_temp  = array(
+		$this->table_logs = 'custom_404_pro_logs';
+	}
+
+	/**
+	 * Returns the default values for all plugin settings.
+	 *
+	 * @return array
+	 */
+	public function defaults(): array {
+		return array(
 			'mode'                => '',
 			'mode_page'           => '',
 			'mode_url'            => '',
-			'send_email'          => '',
-			'logging_enabled'     => '',
+			'send_email'          => false,
+			'logging_enabled'     => false,
 			'redirect_error_code' => 302,
 			'log_ip'              => true,
 		);
-		foreach ( $options_defaults_temp as $key => $value ) {
-			$obj        = new stdClass();
-			$obj->name  = $key;
-			$obj->value = $value;
-			array_push( $this->options_defaults, $obj );
+	}
+
+	/**
+	 * Returns all plugin settings, falling back to defaults for any missing keys.
+	 *
+	 * @return array
+	 */
+	public function get_settings(): array {
+		$saved = get_option( self::OPTION_KEY );
+		if ( ! is_array( $saved ) ) {
+			return $this->defaults();
 		}
+		return array_merge( $this->defaults(), $saved );
+	}
+
+	/**
+	 * Returns a single setting value by key.
+	 *
+	 * @param string $key Setting key.
+	 * @return mixed Setting value, or the default for that key if not set.
+	 */
+	public function get_setting( string $key ) {
+		$settings = $this->get_settings();
+		return $settings[ $key ] ?? $this->defaults()[ $key ] ?? null;
+	}
+
+	/**
+	 * Merges the supplied values into the current settings and persists them.
+	 *
+	 * Only the keys present in $new_settings are updated; all other settings
+	 * retain their current values.
+	 *
+	 * @param array $new_settings Key/value pairs to update.
+	 * @return bool True on success, false on failure.
+	 */
+	public function update_settings( array $new_settings ): bool {
+		$merged = array_merge( $this->get_settings(), $new_settings );
+		return (bool) update_option( self::OPTION_KEY, $merged );
 	}
 
 	/**
@@ -89,118 +119,6 @@ class Helpers {
 		$html .= '   <p>' . $message . '</p>';
 		$html .= '</div>';
 		return $html;
-	}
-
-	/**
-	 * Inserts default option rows into the options table.
-	 */
-	public function initialize_table_options() {
-		global $wpdb;
-		if ( current_user_can( 'manage_options' ) ) {
-			$count = count( $this->options_defaults );
-			$sql   = 'INSERT INTO ' . $wpdb->prefix . $this->table_options . ' (name, value) VALUES '; // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-			foreach ( $this->options_defaults as $key => $option ) {
-				if ( ( $count - 1 ) !== $key ) {
-					$sql .= "('" . $option->name . "', '" . $option->value . "'),";
-				} else {
-					$sql .= "('" . $option->name . "', '" . $option->value . "')";
-				}
-			}
-			$wpdb->query( $sql ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
-		}
-	}
-
-	/**
-	 * Checks whether an option exists in the options table.
-	 *
-	 * @param string $option_name Option name.
-	 * @return object|false Row object if found, false if not.
-	 */
-	public function is_option( $option_name ) {
-		global $wpdb;
-		if ( current_user_can( 'manage_options' ) ) {
-			$query  = $wpdb->prepare( 'SELECT * FROM ' . $wpdb->prefix . $this->table_options . ' WHERE name = %s', $option_name ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-			$result = $wpdb->get_results( $query ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
-			if ( empty( $result ) ) {
-				return false;
-			} else {
-				return $result[0];
-			}
-		}
-	}
-
-	/**
-	 * Retrieves a single option value from the options table.
-	 *
-	 * @param string $option_name Option name.
-	 * @return string|null Option value or null.
-	 */
-	public function get_option( $option_name ) {
-		global $wpdb;
-		if ( current_user_can( 'manage_options' ) ) {
-			$query  = $wpdb->prepare( 'SELECT value FROM ' . $wpdb->prefix . $this->table_options . ' WHERE name = %s', $option_name ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-			$result = $wpdb->get_var( $query ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
-			return $result;
-		}
-	}
-
-	/**
-	 * Inserts a new option into the options table.
-	 *
-	 * @param string $option_name  Option name.
-	 * @param mixed  $option_value Option value.
-	 * @return int|false Number of rows inserted, or false on error.
-	 */
-	public function insert_option( $option_name, $option_value ) {
-		global $wpdb;
-		if ( current_user_can( 'manage_options' ) ) {
-			$result = $wpdb->insert( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
-				$wpdb->prefix . $this->table_options,
-				array(
-					'name'  => $option_name,
-					'value' => $option_value,
-				)
-			);
-			return $result;
-		}
-	}
-
-	/**
-	 * Updates an existing option in the options table.
-	 *
-	 * @param string $option_name  Option name.
-	 * @param mixed  $option_value New option value.
-	 * @return int|false Number of rows updated, or false on error.
-	 */
-	public function update_option( $option_name, $option_value ) {
-		global $wpdb;
-		if ( current_user_can( 'manage_options' ) ) {
-			$result = $wpdb->update( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-				$wpdb->prefix . $this->table_options,
-				array( 'value' => $option_value ),
-				array( 'name' => $option_name )
-			);
-			return $result;
-		}
-	}
-
-	/**
-	 * Inserts or updates an option in the options table.
-	 *
-	 * @param string $option_name  Option name.
-	 * @param mixed  $option_value Option value.
-	 * @return int|false Number of rows affected, or false on error.
-	 */
-	public function upsert_option( $option_name, $option_value ) {
-		global $wpdb;
-		if ( current_user_can( 'manage_options' ) ) {
-			if ( self::is_option( $option_name ) ) {
-				$result = self::update_option( $option_name, $option_value );
-			} else {
-				$result = self::insert_option( $option_name, $option_value );
-			}
-			return $result;
-		}
 	}
 
 	/**
@@ -237,7 +155,6 @@ class Helpers {
 	 * @param array $log_ids Array of post IDs to delete.
 	 */
 	public function delete_old_logs( $log_ids ) {
-		global $wpdb;
 		if ( current_user_can( 'manage_options' ) ) {
 			foreach ( $log_ids as $id ) {
 				wp_delete_post( $id, true );

--- a/admin/class-helpers.php
+++ b/admin/class-helpers.php
@@ -54,6 +54,7 @@ class Helpers {
 	/**
 	 * Returns the default values for all plugin settings.
 	 *
+	 * @since 3.12.9
 	 * @return array
 	 */
 	public function defaults(): array {
@@ -71,6 +72,7 @@ class Helpers {
 	/**
 	 * Returns all plugin settings, falling back to defaults for any missing keys.
 	 *
+	 * @since 3.12.9
 	 * @return array
 	 */
 	public function get_settings(): array {
@@ -84,6 +86,7 @@ class Helpers {
 	/**
 	 * Returns a single setting value by key.
 	 *
+	 * @since 3.12.9
 	 * @param string $key Setting key.
 	 * @return mixed Setting value, or the default for that key if not set.
 	 */
@@ -98,6 +101,7 @@ class Helpers {
 	 * Only the keys present in $new_settings are updated; all other settings
 	 * retain their current values.
 	 *
+	 * @since 3.12.9
 	 * @param array $new_settings Key/value pairs to update.
 	 * @return bool True on success, false on failure.
 	 */
@@ -155,10 +159,8 @@ class Helpers {
 	 * @param array $log_ids Array of post IDs to delete.
 	 */
 	public function delete_old_logs( $log_ids ) {
-		if ( current_user_can( 'manage_options' ) ) {
-			foreach ( $log_ids as $id ) {
-				wp_delete_post( $id, true );
-			}
+		foreach ( $log_ids as $id ) {
+			wp_delete_post( $id, true );
 		}
 	}
 

--- a/admin/class-helpers.php
+++ b/admin/class-helpers.php
@@ -132,11 +132,9 @@ class Helpers {
 	 */
 	public function get_logs_columns() {
 		global $wpdb;
-		if ( current_user_can( 'manage_options' ) ) {
-			$query  = 'SHOW COLUMNS FROM ' . $wpdb->prefix . $this->table_logs; // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-			$result = $wpdb->get_results( $query ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
-			return $result;
-		}
+		$query  = 'SHOW COLUMNS FROM ' . $wpdb->prefix . $this->table_logs; // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$result = $wpdb->get_results( $query ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+		return $result;
 	}
 
 	/**
@@ -146,11 +144,9 @@ class Helpers {
 	 */
 	public function get_old_logs_count() {
 		global $wpdb;
-		if ( current_user_can( 'manage_options' ) ) {
-			$query  = $wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->prefix}posts WHERE post_type = %s", 'c4p_log' ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-			$result = $wpdb->get_var( $query ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
-			return (int) $result;
-		}
+		$query  = $wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->prefix}posts WHERE post_type = %s", 'c4p_log' ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$result = $wpdb->get_var( $query ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+		return (int) $result;
 	}
 
 	/**
@@ -173,30 +169,28 @@ class Helpers {
 	 */
 	public function create_logs( $logs_data, $is_deleting_old ) {
 		global $wpdb;
-		if ( current_user_can( 'manage_options' ) ) {
-			$log_ids = array();
-			$result  = false;
-			foreach ( $logs_data as $log ) {
-				if ( ! empty( $log->id ) ) {
-					array_push( $log_ids, $log->id );
-				}
-				$result = $wpdb->insert( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
-					$wpdb->prefix . $this->table_logs,
-					array(
-						'ip'         => $log->ip,
-						'path'       => $log->path,
-						'referer'    => $log->referer,
-						'user_agent' => $log->user_agent,
-					)
-				);
+		$log_ids = array();
+		$result  = false;
+		foreach ( $logs_data as $log ) {
+			if ( ! empty( $log->id ) ) {
+				array_push( $log_ids, $log->id );
 			}
-			if ( ! is_wp_error( $result ) ) {
-				if ( ! empty( $is_deleting_old ) && $is_deleting_old ) {
-					self::delete_old_logs( $log_ids );
-				}
-			}
-			return $result;
+			$result = $wpdb->insert( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+				$wpdb->prefix . $this->table_logs,
+				array(
+					'ip'         => $log->ip,
+					'path'       => $log->path,
+					'referer'    => $log->referer,
+					'user_agent' => $log->user_agent,
+				)
+			);
 		}
+		if ( ! is_wp_error( $result ) ) {
+			if ( ! empty( $is_deleting_old ) && $is_deleting_old ) {
+				self::delete_old_logs( $log_ids );
+			}
+		}
+		return $result;
 	}
 
 	/**
@@ -206,11 +200,9 @@ class Helpers {
 	 */
 	public function get_logs() {
 		global $wpdb;
-		if ( current_user_can( 'manage_options' ) ) {
-			$query  = 'SELECT * FROM ' . $wpdb->prefix . $this->table_logs; // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-			$result = $wpdb->get_results( $query, ARRAY_A ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
-			return $result;
-		}
+		$query  = 'SELECT * FROM ' . $wpdb->prefix . $this->table_logs; // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$result = $wpdb->get_results( $query, ARRAY_A ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+		return $result;
 	}
 
 	/**
@@ -221,51 +213,47 @@ class Helpers {
 	 */
 	public function delete_logs( $path ) {
 		global $wpdb;
-		if ( current_user_can( 'manage_options' ) ) {
-			if ( 'all' === $path ) {
-				$query  = 'TRUNCATE TABLE ' . $wpdb->prefix . $this->table_logs; // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-				$result = $wpdb->query( $query ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
-			} elseif ( is_array( $path ) ) {
-				$ids          = array_map( 'absint', $path );
-				$placeholders = implode( ',', array_fill( 0, count( $ids ), '%d' ) );
-				$query        = $wpdb->prepare( 'DELETE FROM ' . $wpdb->prefix . $this->table_logs . ' WHERE id IN (' . $placeholders . ')', ...$ids ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.PreparedSQLPlaceholders, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
-				$result       = $wpdb->query( $query ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
-			} else {
-				$query  = $wpdb->prepare( 'DELETE FROM ' . $wpdb->prefix . $this->table_logs . ' WHERE id = %d', $path ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-				$result = $wpdb->query( $query ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
-			}
-			return $result;
+		if ( 'all' === $path ) {
+			$query  = 'TRUNCATE TABLE ' . $wpdb->prefix . $this->table_logs; // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			$result = $wpdb->query( $query ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+		} elseif ( is_array( $path ) ) {
+			$ids          = array_map( 'absint', $path );
+			$placeholders = implode( ',', array_fill( 0, count( $ids ), '%d' ) );
+			$query        = $wpdb->prepare( 'DELETE FROM ' . $wpdb->prefix . $this->table_logs . ' WHERE id IN (' . $placeholders . ')', ...$ids ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.PreparedSQLPlaceholders, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+			$result       = $wpdb->query( $query ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+		} else {
+			$query  = $wpdb->prepare( 'DELETE FROM ' . $wpdb->prefix . $this->table_logs . ' WHERE id = %d', $path ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			$result = $wpdb->query( $query ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
 		}
+		return $result;
 	}
 
 	/**
 	 * Exports all log entries as a CSV file download.
 	 */
 	public function export_logs_csv() {
-		if ( current_user_can( 'manage_options' ) ) {
-			$filename   = 'logs_' . time() . '.csv';
-			$csv_output = '';
-			$columns    = self::get_logs_columns();
-			if ( ! empty( $columns ) ) {
-				foreach ( $columns as $column ) {
-					$csv_output .= $column->Field . ', '; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Field is a wpdb column object property
-				}
+		$filename   = 'logs_' . time() . '.csv';
+		$csv_output = '';
+		$columns    = self::get_logs_columns();
+		if ( ! empty( $columns ) ) {
+			foreach ( $columns as $column ) {
+				$csv_output .= $column->Field . ', '; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Field is a wpdb column object property
 			}
-			$csv_output .= "\n";
-			$results     = self::get_logs();
-			if ( ! empty( $results ) ) {
-				foreach ( $results as $result ) {
-					foreach ( $result as $q ) {
-						$csv_output .= '"' . $q . '", ';
-					}
-					$csv_output .= "\n";
-				}
-			}
-			header( 'Content-Type: application/csv' );
-			header( 'Content-Disposition: attachment; filename=' . $filename );
-			header( 'Pragma: no-cache' );
-			print $csv_output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- CSV download, not HTML output
-			exit;
 		}
+		$csv_output .= "\n";
+		$results     = self::get_logs();
+		if ( ! empty( $results ) ) {
+			foreach ( $results as $result ) {
+				foreach ( $result as $q ) {
+					$csv_output .= '"' . $q . '", ';
+				}
+				$csv_output .= "\n";
+			}
+		}
+		header( 'Content-Type: application/csv' );
+		header( 'Content-Disposition: attachment; filename=' . $filename );
+		header( 'Pragma: no-cache' );
+		print $csv_output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- CSV download, not HTML output
+		exit;
 	}
 }

--- a/admin/views/settings-general.php
+++ b/admin/views/settings-general.php
@@ -5,15 +5,10 @@
  * @package Custom_404_Pro
  */
 
-global $wpdb;
-$helpers = Helpers::singleton();
-$rows    = $wpdb->get_results( 'SELECT name, value FROM ' . $wpdb->prefix . $helpers->table_options ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-$options = array();
-foreach ( $rows as $row ) {
-	$options[ $row->name ] = $row->value;
-}
-$send_email          = $options['send_email'] ?? '';
-$logging_enabled     = $options['logging_enabled'] ?? '';
+$helpers             = Helpers::singleton();
+$options             = $helpers->get_settings();
+$send_email          = $options['send_email'] ?? false;
+$logging_enabled     = $options['logging_enabled'] ?? false;
 $redirect_error_code = isset( $options['redirect_error_code'] ) ? (int) $options['redirect_error_code'] : 302;
 $log_ip              = $options['log_ip'] ?? true;
 ?>

--- a/admin/views/settings-global-redirect.php
+++ b/admin/views/settings-global-redirect.php
@@ -5,25 +5,19 @@
  * @package Custom_404_Pro
  */
 
-global $wpdb;
-$args               = array(
-	'post_type'   => 'page',
-	'post_status' => 'publish',
-);
-$wp_pages           = get_pages( $args );
-$sql_mode           = $wpdb->prepare( 'SELECT value FROM ' . $wpdb->prefix . 'custom_404_pro_options WHERE name = %s', 'mode' ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-$redirect_mode      = $wpdb->get_var( $sql_mode ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+$helpers            = Helpers::singleton();
+$options            = $helpers->get_settings();
+$wp_pages           = get_pages( array( 'post_status' => 'publish' ) );
+$redirect_mode      = $options['mode'] ?? '';
 $redirect_mode_page = '';
 $redirect_mode_url  = '';
+
 if ( 'page' === $redirect_mode ) {
-	$sql_mode_page      = $wpdb->prepare( 'SELECT value FROM ' . $wpdb->prefix . 'custom_404_pro_options WHERE name = %s', 'mode_page' ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-	$redirect_mode_page = $wpdb->get_var( $sql_mode_page ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
 	// Resolve the stored default-language ID to the current admin language so
 	// the correct page appears selected when WPML or Polylang is active.
-	$redirect_mode_page = $this->resolve_multilingual_page_id( (int) $redirect_mode_page );
+	$redirect_mode_page = $this->resolve_multilingual_page_id( (int) ( $options['mode_page'] ?? 0 ) );
 } elseif ( 'url' === $redirect_mode ) {
-	$sql_mode_url      = $wpdb->prepare( 'SELECT value FROM ' . $wpdb->prefix . 'custom_404_pro_options WHERE name = %s', 'mode_url' ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-	$redirect_mode_url = $wpdb->get_var( $sql_mode_url ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+	$redirect_mode_url = $options['mode_url'] ?? '';
 }
 ?>
 <div class="wrap">

--- a/custom-404-pro.php
+++ b/custom-404-pro.php
@@ -18,6 +18,8 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
+define( 'CUSTOM_404_PRO_VERSION', '3.12.9' );
+
 /**
  * Runs on plugin activation.
  */

--- a/custom-404-pro.php
+++ b/custom-404-pro.php
@@ -3,7 +3,7 @@
  * Plugin Name: Custom 404 Pro
  * Plugin URI: https://wordpress.org/plugins/custom-404-pro/
  * Description: Override the default 404 page with any page or a custom URL from the Admin Panel.
- * Version: 3.12.8
+ * Version: 3.12.9
  * Author: Kunal Nagar
  * Author URI: https://www.kunalnagar.in
  * License: GPL-2.0+

--- a/includes/class-activateclass.php
+++ b/includes/class-activateclass.php
@@ -11,82 +11,104 @@
 class ActivateClass {
 
 	/**
-	 * Creates tables and initialises options for a single site.
+	 * Creates the logs table and seeds default settings for a single site.
 	 */
 	private static function run_activation() {
-		global $wpdb;
-		$helpers                = Helpers::singleton();
-		$is_table_options_query = $wpdb->prepare( 'SHOW TABLES LIKE %s', $wpdb->prefix . $helpers->table_options ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-		$is_table_logs_query    = $wpdb->prepare( 'SHOW TABLES LIKE %s', $wpdb->prefix . $helpers->table_logs ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-		$is_table_options       = $wpdb->query( $is_table_options_query ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
-		$is_table_logs          = $wpdb->query( $is_table_logs_query ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
-		if ( empty( $is_table_options ) && empty( $is_table_logs ) ) {
-			self::create_tables();
-			self::initialize_options();
-		}
+		self::create_tables();
+		self::maybe_migrate_legacy_options();
+		self::initialize_options();
 	}
 
 	/**
 	 * Runs on plugin activation, handling multisite if needed.
+	 *
+	 * No capability check here — WordPress core already enforces that only users
+	 * with activate_plugins can trigger this hook, and the check would silently
+	 * break activation via WP-CLI or automated deployment pipelines.
 	 */
 	public static function activate() {
-		global $wpdb;
-		if ( current_user_can( 'manage_options' ) ) {
-			if ( is_multisite() ) {
-				$sites = get_sites( array( 'fields' => 'ids' ) );
-				foreach ( $sites as $blog_id ) {
-					switch_to_blog( $blog_id );
-					self::run_activation();
-					restore_current_blog();
-				}
-			} else {
+		if ( is_multisite() ) {
+			$sites = get_sites( array( 'fields' => 'ids' ) );
+			foreach ( $sites as $blog_id ) {
+				switch_to_blog( $blog_id );
 				self::run_activation();
+				restore_current_blog();
 			}
+		} else {
+			self::run_activation();
 		}
 	}
 
 	/**
-	 * Creates the plugin database tables.
+	 * Creates the plugin logs table.
+	 *
+	 * The legacy options table is no longer created here — settings are stored
+	 * in wp_options under the Helpers::OPTION_KEY key.
 	 */
 	public static function create_tables() {
 		global $wpdb;
-		$helpers       = Helpers::singleton();
-		$table_options = $wpdb->prefix . $helpers->table_options;
-		$table_logs    = $wpdb->prefix . $helpers->table_logs;
-		if ( current_user_can( 'manage_options' ) ) {
-			$charset_collate = $wpdb->get_charset_collate();
-			$sql_logs        = "CREATE TABLE $table_logs (
-    			id mediumint(9) NOT NULL AUTO_INCREMENT,
-    			ip text,
-    			path text,
-    			referer text,
-    			user_agent text,
-    			created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    			updated TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    		  	PRIMARY KEY (id)
-    		) $charset_collate;";
-			$sql_options     = "CREATE TABLE $table_options (
-    			id mediumint(9) NOT NULL AUTO_INCREMENT,
-    			name text,
-    			value text,
-    		  	created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    		  	updated TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    		  	PRIMARY KEY (id)
-    		) $charset_collate;";
-			include_once ABSPATH . 'wp-admin/includes/upgrade.php';
-			dbDelta( $sql_logs );
-			dbDelta( $sql_options );
-		}
+		$helpers         = Helpers::singleton();
+		$table_logs      = $wpdb->prefix . $helpers->table_logs;
+		$charset_collate = $wpdb->get_charset_collate();
+		$sql_logs        = "CREATE TABLE $table_logs (
+    		id mediumint(9) NOT NULL AUTO_INCREMENT,
+    		ip text,
+    		path text,
+    		referer text,
+    		user_agent text,
+    		created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    		updated TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    	  	PRIMARY KEY (id)
+    	) $charset_collate;";
+		include_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $sql_logs );
 	}
 
 	/**
-	 * Inserts default option values into the options table.
+	 * Seeds default settings into wp_options if they have not been set yet.
+	 *
+	 * Uses add_option() which is a no-op when the key already exists, making
+	 * this safe to call on every activation without overwriting saved settings.
 	 */
 	public static function initialize_options() {
+		$helpers = Helpers::singleton();
+		add_option( Helpers::OPTION_KEY, $helpers->defaults() );
+	}
+
+	/**
+	 * Migrates settings from the legacy custom_404_pro_options table to wp_options.
+	 *
+	 * If the legacy table does not exist this method returns immediately. After a
+	 * successful migration the legacy table is dropped. Safe to call multiple
+	 * times — subsequent calls are a no-op once the table is gone.
+	 */
+	public static function maybe_migrate_legacy_options() {
 		global $wpdb;
-		if ( current_user_can( 'manage_options' ) ) {
-			$helpers = Helpers::singleton();
-			$helpers->initialize_table_options();
+		$legacy_table = $wpdb->prefix . 'custom_404_pro_options';
+
+		// Nothing to migrate if the legacy table does not exist.
+		$table_exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $legacy_table ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		if ( ! $table_exists ) {
+			return;
 		}
+
+		// Already migrated — just clean up the legacy table.
+		if ( get_option( Helpers::OPTION_KEY ) ) {
+			$wpdb->query( 'DROP TABLE IF EXISTS ' . $legacy_table ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			return;
+		}
+
+		// Read legacy rows and build a settings array.
+		$rows = $wpdb->get_results( 'SELECT name, value FROM ' . $legacy_table, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		if ( ! empty( $rows ) ) {
+			$settings = array();
+			foreach ( $rows as $row ) {
+				$settings[ $row['name'] ] = $row['value'];
+			}
+			update_option( Helpers::OPTION_KEY, $settings );
+		}
+
+		// Drop the legacy table.
+		$wpdb->query( 'DROP TABLE IF EXISTS ' . $legacy_table ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 	}
 }

--- a/includes/class-activateclass.php
+++ b/includes/class-activateclass.php
@@ -17,6 +17,12 @@ class ActivateClass {
 		self::create_tables();
 		self::maybe_migrate_legacy_options();
 		self::initialize_options();
+
+		// Record the schema version so the plugins_loaded migration check can
+		// skip the SHOW TABLES query on every subsequent page load.
+		if ( defined( 'CUSTOM_404_PRO_VERSION' ) ) {
+			update_option( 'custom_404_pro_db_version', CUSTOM_404_PRO_VERSION );
+		}
 	}
 
 	/**
@@ -25,6 +31,8 @@ class ActivateClass {
 	 * No capability check here — WordPress core already enforces that only users
 	 * with activate_plugins can trigger this hook, and the check would silently
 	 * break activation via WP-CLI or automated deployment pipelines.
+	 *
+	 * @since 3.12.9
 	 */
 	public static function activate() {
 		if ( is_multisite() ) {
@@ -44,6 +52,8 @@ class ActivateClass {
 	 *
 	 * The legacy options table is no longer created here — settings are stored
 	 * in wp_options under the Helpers::OPTION_KEY key.
+	 *
+	 * @since 3.12.9
 	 */
 	public static function create_tables() {
 		global $wpdb;
@@ -69,6 +79,8 @@ class ActivateClass {
 	 *
 	 * Uses add_option() which is a no-op when the key already exists, making
 	 * this safe to call on every activation without overwriting saved settings.
+	 *
+	 * @since 3.12.9
 	 */
 	public static function initialize_options() {
 		$helpers = Helpers::singleton();
@@ -81,6 +93,11 @@ class ActivateClass {
 	 * If the legacy table does not exist this method returns immediately. After a
 	 * successful migration the legacy table is dropped. Safe to call multiple
 	 * times — subsequent calls are a no-op once the table is gone.
+	 *
+	 * Values are cast to their correct types (bool, int) using the defaults map
+	 * so that string values from the old text columns are not carried forward.
+	 *
+	 * @since 3.12.9
 	 */
 	public static function maybe_migrate_legacy_options() {
 		global $wpdb;
@@ -98,12 +115,24 @@ class ActivateClass {
 			return;
 		}
 
-		// Read legacy rows and build a settings array.
+		// Read legacy rows and build a settings array, casting each value to the
+		// correct type so that legacy text-column strings do not persist as strings
+		// where booleans or integers are expected.
 		$rows = $wpdb->get_results( 'SELECT name, value FROM ' . $legacy_table, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		if ( ! empty( $rows ) ) {
+			$defaults = ( new Helpers() )->defaults();
 			$settings = array();
 			foreach ( $rows as $row ) {
-				$settings[ $row['name'] ] = $row['value'];
+				$key   = $row['name'];
+				$value = $row['value'];
+				if ( array_key_exists( $key, $defaults ) ) {
+					if ( is_bool( $defaults[ $key ] ) ) {
+						$value = ! empty( $value ) && '0' !== $value;
+					} elseif ( is_int( $defaults[ $key ] ) ) {
+						$value = (int) $value;
+					}
+				}
+				$settings[ $key ] = $value;
 			}
 			update_option( Helpers::OPTION_KEY, $settings );
 		}

--- a/includes/class-pluginclass.php
+++ b/includes/class-pluginclass.php
@@ -35,6 +35,17 @@ class PluginClass {
 	}
 
 	/**
+	 * Runs the legacy options table migration on first load after an upgrade.
+	 *
+	 * Existing installations that update without deactivating/reactivating will
+	 * not trigger register_activation_hook. This hook ensures the migration runs
+	 * automatically on the first page load of the new version.
+	 */
+	public function maybe_migrate_legacy_options() {
+		ActivateClass::maybe_migrate_legacy_options();
+	}
+
+	/**
 	 * Loads the plugin text domain for translation.
 	 */
 	public function load_textdomain() {
@@ -46,6 +57,7 @@ class PluginClass {
 	 */
 	private function define_admin_hooks() {
 		add_action( 'plugins_loaded', array( $this, 'load_textdomain' ) );
+		add_action( 'plugins_loaded', array( $this, 'maybe_migrate_legacy_options' ) );
 		add_action( 'admin_menu', array( $this->plugin_admin, 'create_menu' ) );
 		add_action( 'admin_enqueue_scripts', array( $this->plugin_admin, 'enqueue_scripts' ) );
 		add_action( 'admin_enqueue_scripts', array( $this->plugin_admin, 'enqueue_styles' ) );

--- a/includes/class-pluginclass.php
+++ b/includes/class-pluginclass.php
@@ -42,6 +42,7 @@ class PluginClass {
 	 * automatically on the first page load of the new version.
 	 */
 	public function maybe_migrate_legacy_options() {
+		include_once plugin_dir_path( __FILE__ ) . 'class-activateclass.php';
 		ActivateClass::maybe_migrate_legacy_options();
 	}
 

--- a/includes/class-pluginclass.php
+++ b/includes/class-pluginclass.php
@@ -40,10 +40,22 @@ class PluginClass {
 	 * Existing installations that update without deactivating/reactivating will
 	 * not trigger register_activation_hook. This hook ensures the migration runs
 	 * automatically on the first page load of the new version.
+	 *
+	 * Gated behind a stored db version so the SHOW TABLES check does not fire
+	 * on every page load once the migration has been completed.
+	 *
+	 * @since 3.12.9
 	 */
 	public function maybe_migrate_legacy_options() {
+		if ( defined( 'CUSTOM_404_PRO_VERSION' ) &&
+			get_option( 'custom_404_pro_db_version' ) === CUSTOM_404_PRO_VERSION ) {
+			return;
+		}
 		include_once plugin_dir_path( __FILE__ ) . 'class-activateclass.php';
 		ActivateClass::maybe_migrate_legacy_options();
+		if ( defined( 'CUSTOM_404_PRO_VERSION' ) ) {
+			update_option( 'custom_404_pro_db_version', CUSTOM_404_PRO_VERSION );
+		}
 	}
 
 	/**

--- a/includes/class-uninstallclass.php
+++ b/includes/class-uninstallclass.php
@@ -13,15 +13,35 @@ class UninstallClass {
 	/**
 	 * Removes all plugin data on uninstall.
 	 *
-	 * Drops the logs table and deletes the settings entry from wp_options.
-	 * The legacy custom_404_pro_options table is also dropped if it still exists
-	 * (e.g. the migration had not run before uninstall).
+	 * On Multisite, data is removed from every site in the network. On single-site
+	 * installs the cleanup runs once for the current site.
 	 */
 	public static function uninstall() {
+		if ( is_multisite() ) {
+			$sites = get_sites( array( 'fields' => 'ids' ) );
+			foreach ( $sites as $blog_id ) {
+				switch_to_blog( $blog_id );
+				self::cleanup_site();
+				restore_current_blog();
+			}
+		} else {
+			self::cleanup_site();
+		}
+	}
+
+	/**
+	 * Removes all plugin data for the current site.
+	 *
+	 * Drops the logs table, deletes the settings and db-version entries from
+	 * wp_options, and drops the legacy options table if the migration had not
+	 * run before uninstall.
+	 */
+	private static function cleanup_site() {
 		global $wpdb;
 
-		// Remove plugin settings from wp_options.
+		// Remove plugin settings and migration marker from wp_options.
 		delete_option( Helpers::OPTION_KEY );
+		delete_option( 'custom_404_pro_db_version' );
 
 		// Drop the logs table.
 		$table_logs = $wpdb->prefix . 'custom_404_pro_logs';

--- a/includes/class-uninstallclass.php
+++ b/includes/class-uninstallclass.php
@@ -11,17 +11,24 @@
 class UninstallClass {
 
 	/**
-	 * Drops plugin database tables on uninstall.
+	 * Removes all plugin data on uninstall.
+	 *
+	 * Drops the logs table and deletes the settings entry from wp_options.
+	 * The legacy custom_404_pro_options table is also dropped if it still exists
+	 * (e.g. the migration had not run before uninstall).
 	 */
 	public static function uninstall() {
 		global $wpdb;
-		if ( current_user_can( 'manage_options' ) ) {
-			$table_logs    = $wpdb->prefix . 'custom_404_pro_logs';
-			$sql_logs      = "DROP TABLE IF EXISTS $table_logs"; // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-			$table_options = $wpdb->prefix . 'custom_404_pro_options';
-			$sql_options   = "DROP TABLE IF EXISTS $table_options"; // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-			$wpdb->query( $sql_logs ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
-			$wpdb->query( $sql_options ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
-		}
+
+		// Remove plugin settings from wp_options.
+		delete_option( Helpers::OPTION_KEY );
+
+		// Drop the logs table.
+		$table_logs = $wpdb->prefix . 'custom_404_pro_logs';
+		$wpdb->query( 'DROP TABLE IF EXISTS ' . $table_logs ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		// Drop the legacy options table if the migration had not run yet.
+		$table_options = $wpdb->prefix . 'custom_404_pro_options';
+		$wpdb->query( 'DROP TABLE IF EXISTS ' . $table_options ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -1,57 +1,84 @@
 === Custom 404 Pro ===
 Contributors: kunalnagar
 Donate link: https://www.paypal.me/kunalnagar88/10
-Tags: 404, 404 error page, custom 404 page, broken link
+Tags: 404, redirect, custom 404, error page, logging
 Requires at least: 3.0.1
 Tested up to: 6.9.4
 Stable tag: 3.12.9
+Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-Override the default 404 page with any page from the Admin Panel or a Custom URL.
+Take control of every 404 on your site — redirect visitors to a custom page or URL, log what broke, and get notified when it matters.
 
 == Description ==
 
-Allows users to replace the default 404 page with a custom page from the Pages section in the Admin Panel. Or you can specify a complete URL to redirect on 404.
+**Custom 404 Pro** replaces WordPress's default 404 behaviour with a proper redirect. Instead of leaving visitors on a dead-end error page, you can send them to any page on your site or an external URL — with the HTTP status code of your choice.
 
-= Important Note =
+= Redirect Modes =
 
-Please open [issues on Github](https://github.com/kunalnagar/custom-404-pro/issues). I will not be using the WordPress.org support area.
+* **WordPress Page** — pick any published page from a dropdown; the plugin redirects to it automatically.
+* **Custom URL** — enter any absolute URL to redirect 404s off-site or to a specific path.
+* **HTTP Status Code** — choose 301, 302, 307, or 308 to match your SEO or caching requirements.
 
-= Features =
+= 404 Logging =
 
-* Full 404 Page Control
-* Record 404 Page Data
-* Custom Page Redirect
-* Custom URL Redirect
+When logging is enabled, the plugin records every 404 hit to a database table so you can see exactly what is broken:
 
-= How does it work? =
+* Request path
+* Visitor IP address (can be disabled for privacy/GDPR compliance)
+* Referrer URL
+* User agent
+* Timestamp
 
-* WordPress Page: Choose a custom page from the Admin Panel
-* URL: Enter a custom URL for 404
-* Stats: List of all 404s
+Logs are searchable and can be deleted individually, in bulk, or all at once. They can also be exported as a CSV file.
+
+= Email Notifications =
+
+Optionally receive an admin email each time a 404 is logged. Designed for low-traffic monitoring — if you expect high 404 volume, keep this off to avoid inbox flooding.
+
+= Multisite Support =
+
+Works correctly on WordPress Multisite installations — activation creates the logs table for each site in the network.
+
+= Multilingual Support =
+
+Compatible with **Polylang** and **WPML**. The redirect page is resolved to the correct language variant for the current visitor automatically.
 
 == Installation ==
 
-* Extract the downloaded ZIP file.
-* Copy the custom-404-pro folder to the wp-content/plugins directory.
-* Activate from the Plugins Section.
+1. Upload the `custom-404-pro` folder to the `/wp-content/plugins/` directory, or install it directly from the WordPress Plugin Directory.
+2. Activate the plugin from the **Plugins** screen.
+3. Go to **Custom 404 Pro → Settings → Global Redirect** and choose a redirect mode (WordPress Page or Custom URL).
+4. Optionally, go to **Custom 404 Pro → Settings → General** to enable logging and email notifications.
 
 == Frequently Asked Questions ==
 
-= Why is the 404 custom redirect not working? =
+= Does this plugin work with page caching plugins? =
 
-Some users have reported an issue with the Divi theme where the 404 redirect does not work. In such cases, please disable the Divi theme and try again. It's usually a good practice to start disabling themes/plugins one by one and work your way backward to see what might be causing the issue.
+Yes, but make sure your caching plugin is not caching 404 responses. If it is, the redirect may not fire. Check your caching plugin's exclusion settings and add 404 status codes or the affected paths to the exclusion list.
 
-= Why are my plugin preferences not being saved? =
+= Why is the 404 redirect not working with the Divi theme? =
 
-Uninstall the plugin from the Plugins page (important!) and reinstall it. Never remove plugin folders directly from your WordPress installation as this DOES NOT cleanup plugin database tables.
+Some users have reported a conflict with the Divi theme. Try switching to a default WordPress theme to confirm the plugin is working, then disable other plugins one by one to isolate the conflict.
+
+= Can I disable IP logging for GDPR compliance? =
+
+Yes. Go to **Settings → General** and uncheck **Log IP**. All future log entries will record `N/A` instead of the visitor's IP address. Existing entries are not modified.
+
+= Why are my settings not saving after a reinstall? =
+
+Always uninstall the plugin from the **Plugins** screen (do not delete the folder directly from the server). Deleting the folder bypasses the uninstall hook and leaves orphaned data in the database. Reinstalling over stale data can cause unexpected behaviour.
+
+= How do I report a bug or request a feature? =
+
+Please open an issue on [GitHub](https://github.com/kunalnagar/custom-404-pro/issues). The WordPress.org support forum is not monitored.
 
 == Screenshots ==
 
-1. Activate the plugin from the WordPress Admin Panel
-2. 404 Logs
-3. Global Settings
+1. 404 Logs table — searchable, exportable, with bulk-delete support
+2. Global Redirect settings — choose a WordPress page or a custom URL
+3. General settings — logging, email notifications, IP recording, and redirect status code
 
 == Changelog ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -57,7 +57,6 @@ Uninstall the plugin from the Plugins page (important!) and reinstall it. Never 
 
 = 3.12.9 =
 * Migrate plugin settings from a custom database table to native wp_options for better compatibility and performance
-* Add configurable email notification cooldown to prevent inbox flooding on high 404 traffic (15 min / 30 min / 1 hr / 6 hr / 24 hr)
 
 = 3.12.8 =
 * Fix IP logging toggle not persisting correctly due to positional row access

--- a/readme.txt
+++ b/readme.txt
@@ -56,6 +56,10 @@ Uninstall the plugin from the Plugins page (important!) and reinstall it. Never 
 == Changelog ==
 
 = 3.12.9 =
+* Migrate plugin settings from a custom database table to native wp_options for better compatibility and performance
+* Add configurable email notification cooldown to prevent inbox flooding on high 404 traffic (15 min / 30 min / 1 hr / 6 hr / 24 hr)
+
+= 3.12.8 =
 * Fix IP logging toggle not persisting correctly due to positional row access
 
 = 3.12.7 =

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.me/kunalnagar88/10
 Tags: 404, 404 error page, custom 404 page, broken link
 Requires at least: 3.0.1
 Tested up to: 6.9.4
-Stable tag: 3.12.8
+Stable tag: 3.12.9
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -55,7 +55,7 @@ Uninstall the plugin from the Plugins page (important!) and reinstall it. Never 
 
 == Changelog ==
 
-= 3.12.8 =
+= 3.12.9 =
 * Fix IP logging toggle not persisting correctly due to positional row access
 
 = 3.12.7 =

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -13,15 +13,16 @@ use PHPUnit\Framework\TestCase;
 class HelpersTest extends TestCase {
 
 	/**
-	 * Asserts that table_options is an explicitly declared property.
+	 * Resets the test options store before each test.
 	 */
-	public function test_table_options_is_declared_property() {
-		$ref = new ReflectionClass( Helpers::class );
-		$this->assertTrue(
-			$ref->hasProperty( 'table_options' ),
-			'table_options must be explicitly declared to avoid PHP 8.2+ deprecation'
-		);
+	protected function setUp(): void {
+		parent::setUp();
+		$GLOBALS['_test_options'] = array();
 	}
+
+	// ------------------------------------------------------------------
+	// Property declarations (PHP 8.2+ dynamic property deprecation guard)
+	// ------------------------------------------------------------------
 
 	/**
 	 * Asserts that table_logs is an explicitly declared property.
@@ -35,24 +36,158 @@ class HelpersTest extends TestCase {
 	}
 
 	/**
-	 * Asserts that options_defaults is an explicitly declared property.
+	 * Asserts that table_logs has the expected value after construction.
 	 */
-	public function test_options_defaults_is_declared_property() {
-		$ref = new ReflectionClass( Helpers::class );
-		$this->assertTrue(
-			$ref->hasProperty( 'options_defaults' ),
-			'options_defaults must be explicitly declared to avoid PHP 8.2+ deprecation'
-		);
+	public function test_table_logs_has_correct_value_after_construction() {
+		$helpers = new Helpers();
+		$this->assertSame( 'custom_404_pro_logs', $helpers->table_logs );
+	}
+
+	// ------------------------------------------------------------------
+	// defaults()
+	// ------------------------------------------------------------------
+
+	/**
+	 * Asserts that defaults() returns an array.
+	 */
+	public function test_defaults_returns_array() {
+		$helpers = new Helpers();
+		$this->assertIsArray( $helpers->defaults() );
 	}
 
 	/**
-	 * Asserts that properties have expected values after construction.
+	 * Asserts that defaults() contains all required setting keys.
 	 */
-	public function test_properties_have_correct_values_after_construction() {
+	public function test_defaults_contains_all_required_keys() {
+		$helpers  = new Helpers();
+		$required = array( 'mode', 'mode_page', 'mode_url', 'send_email', 'logging_enabled', 'redirect_error_code', 'log_ip' );
+		foreach ( $required as $key ) {
+			$this->assertArrayHasKey( $key, $helpers->defaults(), "defaults() should contain key '{$key}'." );
+		}
+	}
+
+	/**
+	 * Asserts that redirect_error_code defaults to 302.
+	 */
+	public function test_defaults_redirect_error_code_is_302() {
 		$helpers = new Helpers();
-		$this->assertSame( 'custom_404_pro_options', $helpers->table_options );
-		$this->assertSame( 'custom_404_pro_logs', $helpers->table_logs );
-		$this->assertIsArray( $helpers->options_defaults );
-		$this->assertNotEmpty( $helpers->options_defaults );
+		$this->assertSame( 302, $helpers->defaults()['redirect_error_code'] );
+	}
+
+	/**
+	 * Asserts that log_ip defaults to true.
+	 */
+	public function test_defaults_log_ip_is_true() {
+		$helpers = new Helpers();
+		$this->assertTrue( $helpers->defaults()['log_ip'] );
+	}
+
+	// ------------------------------------------------------------------
+	// get_settings()
+	// ------------------------------------------------------------------
+
+	/**
+	 * Asserts that get_settings() returns the defaults when no option is stored.
+	 */
+	public function test_get_settings_returns_defaults_when_no_option_stored() {
+		$helpers = new Helpers();
+		$this->assertSame( $helpers->defaults(), $helpers->get_settings() );
+	}
+
+	/**
+	 * Asserts that get_settings() returns stored values merged over defaults.
+	 */
+	public function test_get_settings_returns_stored_values() {
+		update_option( Helpers::OPTION_KEY, array( 'mode' => 'url', 'mode_url' => 'https://example.com' ) );
+		$helpers   = new Helpers();
+		$settings  = $helpers->get_settings();
+		$this->assertSame( 'url', $settings['mode'] );
+		$this->assertSame( 'https://example.com', $settings['mode_url'] );
+	}
+
+	/**
+	 * Asserts that get_settings() fills in missing keys from defaults.
+	 */
+	public function test_get_settings_fills_missing_keys_from_defaults() {
+		update_option( Helpers::OPTION_KEY, array( 'mode' => 'url' ) );
+		$helpers  = new Helpers();
+		$settings = $helpers->get_settings();
+		$this->assertSame( 302, $settings['redirect_error_code'] );
+		$this->assertTrue( $settings['log_ip'] );
+	}
+
+	// ------------------------------------------------------------------
+	// get_setting()
+	// ------------------------------------------------------------------
+
+	/**
+	 * Asserts that get_setting() returns the value for a stored key.
+	 */
+	public function test_get_setting_returns_stored_value() {
+		update_option( Helpers::OPTION_KEY, array( 'mode' => 'page' ) );
+		$helpers = new Helpers();
+		$this->assertSame( 'page', $helpers->get_setting( 'mode' ) );
+	}
+
+	/**
+	 * Asserts that get_setting() returns the default when the key is not in the stored option.
+	 */
+	public function test_get_setting_returns_default_for_missing_key() {
+		update_option( Helpers::OPTION_KEY, array() );
+		$helpers = new Helpers();
+		$this->assertSame( 302, $helpers->get_setting( 'redirect_error_code' ) );
+	}
+
+	/**
+	 * Asserts that get_setting() returns null for an unknown key.
+	 */
+	public function test_get_setting_returns_null_for_unknown_key() {
+		$helpers = new Helpers();
+		$this->assertNull( $helpers->get_setting( 'nonexistent_key' ) );
+	}
+
+	// ------------------------------------------------------------------
+	// update_settings()
+	// ------------------------------------------------------------------
+
+	/**
+	 * Asserts that update_settings() persists the supplied values.
+	 */
+	public function test_update_settings_persists_values() {
+		$helpers = new Helpers();
+		$helpers->update_settings( array( 'mode' => 'url', 'mode_url' => 'https://example.com' ) );
+		$this->assertSame( 'url', $helpers->get_setting( 'mode' ) );
+		$this->assertSame( 'https://example.com', $helpers->get_setting( 'mode_url' ) );
+	}
+
+	/**
+	 * Asserts that update_settings() merges with existing values rather than replacing them.
+	 */
+	public function test_update_settings_merges_with_existing_values() {
+		$helpers = new Helpers();
+		$helpers->update_settings( array( 'mode' => 'url' ) );
+		$helpers->update_settings( array( 'mode_url' => 'https://example.com' ) );
+		// Both keys should be present.
+		$this->assertSame( 'url', $helpers->get_setting( 'mode' ) );
+		$this->assertSame( 'https://example.com', $helpers->get_setting( 'mode_url' ) );
+	}
+
+	/**
+	 * Asserts that update_settings() does not overwrite keys not included in the update.
+	 */
+	public function test_update_settings_preserves_untouched_keys() {
+		$helpers = new Helpers();
+		$helpers->update_settings( array( 'redirect_error_code' => 301 ) );
+		$helpers->update_settings( array( 'mode' => 'url' ) );
+		// redirect_error_code should still be 301.
+		$this->assertSame( 301, $helpers->get_setting( 'redirect_error_code' ) );
+	}
+
+	/**
+	 * Asserts that update_settings() returns true on success.
+	 */
+	public function test_update_settings_returns_true() {
+		$helpers = new Helpers();
+		$this->assertTrue( $helpers->update_settings( array( 'mode' => '' ) ) );
 	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,9 +10,10 @@ $wpdb         = new stdClass(); // phpcs:ignore WordPress.WP.GlobalVariablesOver
 $wpdb->prefix = 'wp_';
 
 // Simple filter/action registries used by stubs below.
-$GLOBALS['_test_filters'] = array();
-$GLOBALS['_test_actions'] = array();
+$GLOBALS['_test_filters']                 = array();
+$GLOBALS['_test_actions']                 = array();
 $GLOBALS['_load_plugin_textdomain_calls'] = array();
+$GLOBALS['_test_options']                 = array();
 
 /**
  * Stub for WordPress apply_filters().
@@ -138,6 +139,65 @@ function load_plugin_textdomain( string $domain, $deprecated = false, $plugin_re
 		'domain'          => $domain,
 		'plugin_rel_path' => $plugin_rel_path,
 	);
+}
+
+/**
+ * Stub for WordPress get_option().
+ *
+ * Returns the value stored in the test options registry, or $default if not set.
+ *
+ * @param string $option  Option name.
+ * @param mixed  $default Default value.
+ * @return mixed
+ */
+function get_option( string $option, $default = false ) {
+	return array_key_exists( $option, $GLOBALS['_test_options'] )
+		? $GLOBALS['_test_options'][ $option ]
+		: $default;
+}
+
+/**
+ * Stub for WordPress update_option().
+ *
+ * Stores a value in the test options registry.
+ *
+ * @param string $option Option name.
+ * @param mixed  $value  Value to store.
+ * @return bool Always true.
+ */
+function update_option( string $option, $value ) {
+	$GLOBALS['_test_options'][ $option ] = $value;
+	return true;
+}
+
+/**
+ * Stub for WordPress add_option().
+ *
+ * Stores a value only when the option is not already set (mirrors WordPress behaviour).
+ *
+ * @param string $option Option name.
+ * @param mixed  $value  Value to store.
+ * @return bool True if the option was added, false if it already existed.
+ */
+function add_option( string $option, $value ) {
+	if ( array_key_exists( $option, $GLOBALS['_test_options'] ) ) {
+		return false;
+	}
+	$GLOBALS['_test_options'][ $option ] = $value;
+	return true;
+}
+
+/**
+ * Stub for WordPress delete_option().
+ *
+ * Removes a value from the test options registry.
+ *
+ * @param string $option Option name.
+ * @return bool Always true.
+ */
+function delete_option( string $option ): bool {
+	unset( $GLOBALS['_test_options'][ $option ] );
+	return true;
 }
 
 require_once dirname( __DIR__ ) . '/admin/class-helpers.php';

--- a/tests/integration/ActivationTest.php
+++ b/tests/integration/ActivationTest.php
@@ -11,50 +11,18 @@
 class C404P_Integration_ActivationTest extends WP_UnitTestCase {
 
 	/**
-	 * Administrator user ID created in setUp.
+	 * Tear down: drop the logs table so DDL does not leak between tests.
 	 *
-	 * @var int
-	 */
-	private $admin_id;
-
-	/**
-	 * Set up: create an administrator user so capability checks pass.
-	 */
-	public function setUp(): void {
-		parent::setUp();
-		$this->admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
-		wp_set_current_user( $this->admin_id );
-	}
-
-	/**
-	 * Tear down: drop both custom tables so DDL does not leak between tests.
-	 *
-	 * dbDelta issues DDL (CREATE TABLE), which implicitly commits the transaction
-	 * that WP_UnitTestCase wraps around DML. The tables must be dropped manually.
+	 * dbDelta issues DDL (CREATE TABLE), which implicitly commits any open
+	 * transaction. The logs table must therefore be dropped manually rather
+	 * than relying on WP_UnitTestCase's transaction rollback.
 	 */
 	public function tearDown(): void {
 		global $wpdb;
 		$helpers = new Helpers();
-		$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . $helpers->table_options ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
 		$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . $helpers->table_logs ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+		delete_option( Helpers::OPTION_KEY );
 		parent::tearDown();
-	}
-
-	/**
-	 * create_tables() should create the options table.
-	 */
-	public function test_create_tables_creates_options_table() {
-		global $wpdb;
-		ActivateClass::create_tables();
-		$helpers = new Helpers();
-		// SELECT COUNT(*) returns '0' (not null) when the table exists but is empty.
-		// It returns null only when the table does not exist (MySQL error). This makes
-		// it a reliable existence check that avoids LIKE wildcard and information_schema
-		// privilege issues.
-		$wpdb->suppress_errors( true );
-		$result = $wpdb->get_var( 'SELECT COUNT(*) FROM ' . $wpdb->prefix . $helpers->table_options ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
-		$wpdb->suppress_errors( false );
-		$this->assertNotNull( $result, 'Options table should exist after create_tables().' );
 	}
 
 	/**
@@ -68,20 +36,6 @@ class C404P_Integration_ActivationTest extends WP_UnitTestCase {
 		$result = $wpdb->get_var( 'SELECT COUNT(*) FROM ' . $wpdb->prefix . $helpers->table_logs ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
 		$wpdb->suppress_errors( false );
 		$this->assertNotNull( $result, 'Logs table should exist after create_tables().' );
-	}
-
-	/**
-	 * Options table should have the expected columns.
-	 */
-	public function test_options_table_has_correct_columns() {
-		global $wpdb;
-		ActivateClass::create_tables();
-		$helpers  = new Helpers();
-		$columns  = $wpdb->get_col( 'SHOW COLUMNS FROM ' . $wpdb->prefix . $helpers->table_options ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
-		$expected = array( 'id', 'name', 'value', 'created', 'updated' );
-		foreach ( $expected as $col ) {
-			$this->assertContains( $col, $columns, "Options table should have column '{$col}'." );
-		}
 	}
 
 	/**
@@ -99,30 +53,44 @@ class C404P_Integration_ActivationTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * initialize_options() should insert one row for each default option key.
+	 * initialize_options() should create the wp_options entry.
 	 */
-	public function test_initialize_options_inserts_all_default_rows() {
-		global $wpdb;
-		ActivateClass::create_tables();
+	public function test_initialize_options_creates_wp_options_entry() {
 		ActivateClass::initialize_options();
-		$helpers  = new Helpers();
-		$count    = (int) $wpdb->get_var( 'SELECT COUNT(*) FROM ' . $wpdb->prefix . $helpers->table_options ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
-		$expected = count( $helpers->options_defaults );
-		$this->assertSame( $expected, $count, "initialize_options() should insert {$expected} rows." );
+		$stored = get_option( Helpers::OPTION_KEY );
+		$this->assertIsArray( $stored, 'initialize_options() should create a wp_options entry.' );
 	}
 
 	/**
-	 * initialize_options() should insert rows for every expected option name.
+	 * initialize_options() should store all default setting keys.
 	 */
-	public function test_initialize_options_inserts_expected_option_names() {
-		global $wpdb;
-		ActivateClass::create_tables();
+	public function test_initialize_options_stores_all_default_keys() {
 		ActivateClass::initialize_options();
-		$helpers        = new Helpers();
-		$inserted_names = $wpdb->get_col( 'SELECT name FROM ' . $wpdb->prefix . $helpers->table_options ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
-		$expected_names = array( 'mode', 'mode_page', 'mode_url', 'send_email', 'logging_enabled', 'redirect_error_code', 'log_ip' );
-		foreach ( $expected_names as $name ) {
-			$this->assertContains( $name, $inserted_names, "Default option '{$name}' should be present after initialize_options()." );
+		$helpers  = new Helpers();
+		$stored   = get_option( Helpers::OPTION_KEY );
+		$expected = array_keys( $helpers->defaults() );
+		foreach ( $expected as $key ) {
+			$this->assertArrayHasKey( $key, $stored, "Default key '{$key}' should be present after initialize_options()." );
 		}
+	}
+
+	/**
+	 * initialize_options() should not overwrite existing settings on re-activation.
+	 */
+	public function test_initialize_options_does_not_overwrite_existing_settings() {
+		// Simulate a saved setting from a previous activation.
+		update_option( Helpers::OPTION_KEY, array( 'mode' => 'url', 'mode_url' => 'https://example.com' ) );
+		ActivateClass::initialize_options();
+		$stored = get_option( Helpers::OPTION_KEY );
+		$this->assertSame( 'url', $stored['mode'], 'Re-activation should not overwrite existing settings.' );
+	}
+
+	/**
+	 * maybe_migrate_legacy_options() should be a no-op when no legacy table exists.
+	 */
+	public function test_maybe_migrate_legacy_options_is_noop_when_no_legacy_table() {
+		ActivateClass::maybe_migrate_legacy_options();
+		// No exception and no wp_options entry created means the no-op path ran.
+		$this->assertFalse( get_option( Helpers::OPTION_KEY ), 'No wp_options entry should be created when there is nothing to migrate.' );
 	}
 }

--- a/tests/integration/HelpersDbTest.php
+++ b/tests/integration/HelpersDbTest.php
@@ -6,7 +6,7 @@
  */
 
 /**
- * Tests every public CRUD method in Helpers against a real MySQL database.
+ * Tests every public method in Helpers that touches the database.
  */
 class C404P_Integration_HelpersDbTest extends WP_UnitTestCase {
 
@@ -22,7 +22,7 @@ class C404P_Integration_HelpersDbTest extends WP_UnitTestCase {
 	private $helpers;
 
 	/**
-	 * Set up: create tables and a Helpers instance with admin privileges.
+	 * Set up: create the logs table and a Helpers instance with admin privileges.
 	 */
 	public function setUp(): void {
 		parent::setUp();
@@ -33,83 +33,43 @@ class C404P_Integration_HelpersDbTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tear down: drop both custom tables.
+	 * Tear down: drop the logs table.
 	 */
 	public function tearDown(): void {
 		global $wpdb;
-		$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . $this->helpers->table_options ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
 		$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . $this->helpers->table_logs ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
 		parent::tearDown();
 	}
 
 	// -------------------------------------------------------------------------
-	// Options CRUD
+	// Settings via wp_options
 	// -------------------------------------------------------------------------
 
 	/**
-	 * insert_option() should persist the value so get_option() returns it.
+	 * get_settings() should return defaults when no option is stored.
 	 */
-	public function test_insert_option_persists_value_in_database() {
-		$this->helpers->insert_option( 'test_key', 'test_value' );
-		$this->assertSame( 'test_value', $this->helpers->get_option( 'test_key' ) );
+	public function test_get_settings_returns_defaults_when_no_option_stored() {
+		$this->assertSame( $this->helpers->defaults(), $this->helpers->get_settings() );
 	}
 
 	/**
-	 * get_option() should return null for a key that was never inserted.
+	 * update_settings() should persist values readable by get_settings().
 	 */
-	public function test_get_option_returns_null_for_nonexistent_key() {
-		$this->assertNull( $this->helpers->get_option( 'nonexistent_key' ) );
+	public function test_update_settings_persists_values() {
+		$this->helpers->update_settings( array( 'mode' => 'url', 'mode_url' => 'https://example.com' ) );
+		$settings = $this->helpers->get_settings();
+		$this->assertSame( 'url', $settings['mode'] );
+		$this->assertSame( 'https://example.com', $settings['mode_url'] );
 	}
 
 	/**
-	 * update_option() should change the stored value.
+	 * update_settings() should merge with existing values rather than replace them.
 	 */
-	public function test_update_option_modifies_existing_row() {
-		$this->helpers->insert_option( 'fruit', 'apple' );
-		$this->helpers->update_option( 'fruit', 'orange' );
-		$this->assertSame( 'orange', $this->helpers->get_option( 'fruit' ) );
-	}
-
-	/**
-	 * is_option() should return a row object for a key that exists.
-	 */
-	public function test_is_option_returns_row_object_for_existing_key() {
-		$this->helpers->insert_option( 'exists', '1' );
-		$row = $this->helpers->is_option( 'exists' );
-		$this->assertIsObject( $row );
-		$this->assertSame( 'exists', $row->name );
-	}
-
-	/**
-	 * is_option() should return false for a key that does not exist.
-	 */
-	public function test_is_option_returns_false_for_missing_key() {
-		$this->assertFalse( $this->helpers->is_option( 'missing_key' ) );
-	}
-
-	/**
-	 * upsert_option() should insert a row when the option does not yet exist.
-	 */
-	public function test_upsert_option_inserts_when_option_does_not_exist() {
-		$this->helpers->upsert_option( 'new_key', 'new_val' );
-		$this->assertSame( 'new_val', $this->helpers->get_option( 'new_key' ) );
-	}
-
-	/**
-	 * upsert_option() should update the value without creating a duplicate row.
-	 */
-	public function test_upsert_option_updates_and_does_not_duplicate() {
-		global $wpdb;
-		$this->helpers->insert_option( 'existing', 'first' );
-		$this->helpers->upsert_option( 'existing', 'second' );
-		$this->assertSame( 'second', $this->helpers->get_option( 'existing' ) );
-		$count = (int) $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-			$wpdb->prepare(
-				'SELECT COUNT(*) FROM ' . $wpdb->prefix . $this->helpers->table_options . ' WHERE name = %s', // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-				'existing'
-			)
-		);
-		$this->assertSame( 1, $count, 'upsert_option() should not create duplicate rows.' );
+	public function test_update_settings_merges_with_existing_values() {
+		$this->helpers->update_settings( array( 'redirect_error_code' => 301 ) );
+		$this->helpers->update_settings( array( 'mode' => 'url' ) );
+		$this->assertSame( 301, (int) $this->helpers->get_setting( 'redirect_error_code' ) );
+		$this->assertSame( 'url', $this->helpers->get_setting( 'mode' ) );
 	}
 
 	// -------------------------------------------------------------------------

--- a/tests/integration/RedirectTest.php
+++ b/tests/integration/RedirectTest.php
@@ -49,7 +49,7 @@ class C404P_Integration_RedirectTest extends WP_UnitTestCase {
 	private $helpers;
 
 	/**
-	 * Set up: create tables, seed default options, configure 404 state.
+	 * Set up: create the logs table, seed default settings, configure 404 state.
 	 */
 	public function setUp(): void {
 		parent::setUp();
@@ -58,7 +58,7 @@ class C404P_Integration_RedirectTest extends WP_UnitTestCase {
 		wp_set_current_user( $admin_id );
 
 		ActivateClass::create_tables();
-		ActivateClass::initialize_options();
+		ActivateClass::initialize_options(); // seeds wp_options defaults via add_option()
 
 		$this->helpers         = new Helpers();
 		$this->admin           = new AdminClass();
@@ -79,7 +79,11 @@ class C404P_Integration_RedirectTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tear down: remove filter, reset globals, drop custom tables.
+	 * Tear down: remove filters, reset globals, drop the logs table.
+	 *
+	 * Settings are stored in wp_options (DML) so they are rolled back automatically
+	 * by WP_UnitTestCase. Only the logs table requires a manual DROP because
+	 * CREATE TABLE is DDL and implicitly commits.
 	 */
 	public function tearDown(): void {
 		global $wpdb;
@@ -89,7 +93,6 @@ class C404P_Integration_RedirectTest extends WP_UnitTestCase {
 
 		unset( $GLOBALS['wp_query'] );
 
-		$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . $this->helpers->table_options ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
 		$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . $this->helpers->table_logs ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
 
 		parent::tearDown();
@@ -136,8 +139,7 @@ class C404P_Integration_RedirectTest extends WP_UnitTestCase {
 	 * URL mode should redirect to the configured URL.
 	 */
 	public function test_redirect_sends_correct_url_in_url_mode() {
-		$this->helpers->update_option( 'mode', 'url' );
-		$this->helpers->update_option( 'mode_url', 'https://example.com/custom-error' );
+		$this->helpers->update_settings( array( 'mode' => 'url', 'mode_url' => 'https://example.com/custom-error' ) );
 
 		$this->admin->custom_404_pro_redirect();
 
@@ -148,9 +150,7 @@ class C404P_Integration_RedirectTest extends WP_UnitTestCase {
 	 * The HTTP status code from the redirect_error_code option should be used.
 	 */
 	public function test_redirect_uses_configured_status_code() {
-		$this->helpers->update_option( 'mode', 'url' );
-		$this->helpers->update_option( 'mode_url', 'https://example.com' );
-		$this->helpers->update_option( 'redirect_error_code', '301' );
+		$this->helpers->update_settings( array( 'mode' => 'url', 'mode_url' => 'https://example.com', 'redirect_error_code' => 301 ) );
 
 		$this->admin->custom_404_pro_redirect();
 
@@ -170,8 +170,7 @@ class C404P_Integration_RedirectTest extends WP_UnitTestCase {
 		);
 		$page    = get_post( $page_id );
 
-		$this->helpers->update_option( 'mode', 'page' );
-		$this->helpers->update_option( 'mode_page', (string) $page_id );
+		$this->helpers->update_settings( array( 'mode' => 'page', 'mode_page' => (string) $page_id ) );
 
 		$this->admin->custom_404_pro_redirect();
 
@@ -184,8 +183,7 @@ class C404P_Integration_RedirectTest extends WP_UnitTestCase {
 	public function test_redirect_does_not_fire_when_not_404() {
 		$GLOBALS['wp_query']->is_404 = false;
 
-		$this->helpers->update_option( 'mode', 'url' );
-		$this->helpers->update_option( 'mode_url', 'https://example.com' );
+		$this->helpers->update_settings( array( 'mode' => 'url', 'mode_url' => 'https://example.com' ) );
 
 		$this->admin->custom_404_pro_redirect();
 
@@ -196,9 +194,7 @@ class C404P_Integration_RedirectTest extends WP_UnitTestCase {
 	 * A log entry should be created when logging is enabled.
 	 */
 	public function test_redirect_creates_log_entry_when_logging_enabled() {
-		$this->helpers->update_option( 'logging_enabled', '1' );
-		$this->helpers->update_option( 'mode', 'url' );
-		$this->helpers->update_option( 'mode_url', 'https://example.com' );
+		$this->helpers->update_settings( array( 'logging_enabled' => true, 'mode' => 'url', 'mode_url' => 'https://example.com' ) );
 
 		$this->admin->custom_404_pro_redirect();
 
@@ -210,9 +206,8 @@ class C404P_Integration_RedirectTest extends WP_UnitTestCase {
 	 * No log entry should be created when logging is disabled (default).
 	 */
 	public function test_redirect_does_not_log_when_logging_disabled() {
-		// Default logging_enabled is '' after initialize_options().
-		$this->helpers->update_option( 'mode', 'url' );
-		$this->helpers->update_option( 'mode_url', 'https://example.com' );
+		// Default logging_enabled is false after initialize_options().
+		$this->helpers->update_settings( array( 'mode' => 'url', 'mode_url' => 'https://example.com' ) );
 
 		$this->admin->custom_404_pro_redirect();
 


### PR DESCRIPTION
Closes #100

## What

Removes the bespoke `custom_404_pro_options` database table and replaces it with a single `wp_options` entry (`custom_404_pro_settings`) storing all plugin settings as a serialised array.

## Why

The custom options table was a well-known WordPress anti-pattern that:
- Reinvented what `wp_options` already does with built-in memory caching, autoloading, and multisite awareness
- Required its own schema creation, CRUD boilerplate (`Helpers`), and teardown on uninstall
- Caused a real bug: the `current_user_can()` guard inside activation silently skipped table creation in CLI/CI contexts (no authenticated user)
- Issued a raw `$wpdb` query on every `template_redirect` hit with no caching

## What changed

| Area | Before | After |
|------|--------|-------|
| Storage | `custom_404_pro_options` table (key/value rows) | `wp_options` entry `custom_404_pro_settings` (array) |
| Settings read | Raw `SELECT` on every request | `get_option()` — cached in memory by WordPress |
| Helpers API | `get_option()`, `update_option()`, `upsert_option()`, `insert_option()`, `is_option()` | `get_settings()`, `get_setting()`, `update_settings()`, `defaults()` |
| Activation | Creates two tables + seeds rows | Creates logs table only + `add_option()` for settings |
| Uninstall | `DROP TABLE` for options | `delete_option()` |
| Upgrade path | Manual deactivate/reactivate | Auto-migration on `plugins_loaded` |

## Migration for existing installs

`ActivateClass::maybe_migrate_legacy_options()` is now hooked onto `plugins_loaded`. On the first page load after upgrading it reads the old table, writes everything to `wp_options`, and drops the legacy table. Subsequent loads skip it in O(1) via `get_option()`.

## Test plan

- [ ] Unit tests pass: `composer test`
- [ ] Integration tests pass: `composer test:integration`
- [ ] Fresh install: confirm `custom_404_pro_settings` appears in `wp_options`, no `custom_404_pro_options` table exists
- [ ] Existing install (with legacy table): confirm settings migrate to `wp_options` on first page load, legacy table is dropped
- [ ] Save settings in admin UI, reload — values persist