### PR TITLE
feat: add configurable log retention policy (v3.14.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ Take full control of your WordPress 404 experience. Custom 404 Pro lets you redi
 - **Admin email alerts** — get notified at your site's admin email address whenever a 404 is logged.
 - **Email cooldown** — configure a quiet period between notifications (15 minutes, 30 minutes, 1 hour, 6 hours, or 24 hours). Once an email is sent, the plugin stays quiet until the cooldown expires — no inbox flooding from bot crawls or broken redirect loops.
 
+### Log Retention
+
+- **Max Log Count** — set a hard cap on how many rows the log table can hold. When the table exceeds the limit, the oldest rows are automatically deleted to bring it back down. Set to `0` to disable (no limit).
+- **Max Log Age (days)** — automatically delete log entries older than a given number of days. Set to `0` to keep logs forever.
+- **Daily background cleanup** — a WP-Cron event runs once per day and applies both retention rules automatically. No manual intervention required.
+- **On-demand pruning** — a **Prune Logs Now** button on the Logs page lets you trigger a cleanup immediately without waiting for the next cron run.
+- Both limits default to `0` — existing installs see no behaviour change until retention is explicitly configured.
+
 ### Compatibility
 
 - **Multisite** — tables and settings are provisioned per-site on activation and cleaned up per-site on uninstall.
@@ -65,6 +73,8 @@ Take full control of your WordPress 404 experience. Custom 404 Pro lets you redi
 | Logging Status | Enabled / Disabled | Disabled | Whether 404 events are captured to the log table |
 | Log IP | On / Off | On | Whether to record the visitor's IP address |
 | Redirect Code | 301 / 302 / 307 / 308 | 302 | HTTP status code used for the redirect |
+| Max Log Count | Any integer ≥ 0 | 0 (disabled) | Delete oldest rows when table exceeds this count; 0 = no limit |
+| Max Log Age (days) | Any integer ≥ 0 | 0 (disabled) | Delete rows older than this many days; 0 = keep forever |
 
 ---
 
@@ -120,7 +130,10 @@ Like the plugin? [Buy me a coffee via PayPal](https://www.paypal.me/kunalnagar/1
 
 See [WordPress.org changelog](https://wordpress.org/plugins/custom-404-pro/changelog/) for the full history.
 
-### 3.12.9
+### 3.14.0
+- Add configurable log retention policy: cap by row count, by age (days), or both. Includes a daily WP-Cron cleanup job and an on-demand Prune Logs Now button on the Logs page.
+
+### 3.13.0
 - Add email notification cooldown to prevent inbox flooding. Configurable from 15 minutes to 24 hours (default: 1 hour).
 
 ### 3.12.8

--- a/admin/class-adminclass.php
+++ b/admin/class-adminclass.php
@@ -140,6 +140,8 @@ class AdminClass {
 			$allowed_cooldowns         = array( 900, 1800, 3600, 21600, 86400 );
 			$raw_cooldown              = isset( $_POST['email_cooldown'] ) ? absint( wp_unslash( $_POST['email_cooldown'] ) ) : HOUR_IN_SECONDS;
 			$field_email_cooldown      = in_array( $raw_cooldown, $allowed_cooldowns, true ) ? $raw_cooldown : HOUR_IN_SECONDS;
+			$log_retention_count = isset( $_POST['log_retention_count'] ) ? absint( wp_unslash( $_POST['log_retention_count'] ) ) : 0;
+			$log_retention_days  = isset( $_POST['log_retention_days'] ) ? absint( wp_unslash( $_POST['log_retention_days'] ) ) : 0;
 			$this->helpers->update_settings(
 				array(
 					'send_email'          => ( 'on' === $send_email ),
@@ -147,6 +149,8 @@ class AdminClass {
 					'log_ip'              => ( 'on' === $log_ip ),
 					'redirect_error_code' => $field_redirect_error_code,
 					'email_cooldown'      => $field_email_cooldown,
+					'log_retention_count' => $log_retention_count,
+					'log_retention_days'  => $log_retention_days,
 				)
 			);
 			$message = rawurlencode( 'Saved!' );
@@ -182,6 +186,12 @@ class AdminClass {
 					exit;
 				} elseif ( 'c4p-logs--export-csv' === $action && wp_verify_nonce( $nonce, 'bulk-logs' ) ) {
 					$this->helpers->export_logs_csv();
+				} elseif ( 'c4p-logs--prune' === $action && wp_verify_nonce( $nonce, 'c4p-logs--prune' ) ) {
+					$deleted = $this->helpers->prune_logs();
+					$message = rawurlencode( sprintf( 'Pruned %d log row(s).', $deleted ) );
+					if ( wp_safe_redirect( admin_url( 'admin.php?page=c4p-main&c4pmessage=' . $message . '&c4pmessageType=success' ) ) ) {
+						exit;
+					}
 				}
 			}
 		}
@@ -280,6 +290,18 @@ class AdminClass {
 	 */
 	public function is_email_on_cooldown(): bool {
 		return (bool) get_transient( 'custom_404_pro_email_cooldown' );
+	}
+
+	/**
+	 * WP-Cron callback: prunes log entries according to retention settings.
+	 *
+	 * Must be public so it can be registered via add_action().
+	 *
+	 * @since 3.14.0
+	 * @return int Total rows deleted.
+	 */
+	public function run_scheduled_log_prune(): int {
+		return $this->helpers->prune_logs();
 	}
 
 	/**

--- a/admin/class-adminclass.php
+++ b/admin/class-adminclass.php
@@ -120,8 +120,9 @@ class AdminClass {
 			$url  = isset( $_POST['mode_url'] ) ? sanitize_text_field( wp_unslash( $_POST['mode_url'] ) ) : '';
 			self::update_mode( $mode, $page, $url );
 			$message = rawurlencode( 'Saved!' );
-			wp_safe_redirect( admin_url( 'admin.php?page=c4p-settings&tab=global-redirect&c4pmessage=' . $message . '&c4pmessageType=success' ) );
-			exit;
+			if ( wp_safe_redirect( admin_url( 'admin.php?page=c4p-settings&tab=global-redirect&c4pmessage=' . $message . '&c4pmessageType=success' ) ) ) {
+				exit;
+			}
 		}
 	}
 
@@ -154,8 +155,9 @@ class AdminClass {
 				)
 			);
 			$message = rawurlencode( 'Saved!' );
-			wp_safe_redirect( admin_url( 'admin.php?page=c4p-settings&tab=general&c4pmessage=' . $message . '&c4pmessageType=success' ) );
-			exit;
+			if ( wp_safe_redirect( admin_url( 'admin.php?page=c4p-settings&tab=general&c4pmessage=' . $message . '&c4pmessageType=success' ) ) ) {
+				exit;
+			}
 		}
 	}
 
@@ -172,18 +174,21 @@ class AdminClass {
 						$path = is_array( $_REQUEST['path'] ) ? array_map( 'absint', $_REQUEST['path'] ) : absint( $_REQUEST['path'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 						$this->helpers->delete_logs( $path );
 						$message = rawurlencode( 'Log(s) successfully deleted!' );
-						wp_safe_redirect( admin_url( 'admin.php?page=c4p-main&c4pmessage=' . $message . '&c4pmessageType=success' ) );
-						exit;
+						if ( wp_safe_redirect( admin_url( 'admin.php?page=c4p-main&c4pmessage=' . $message . '&c4pmessageType=success' ) ) ) {
+							exit;
+						}
 					} else {
 						$message = rawurlencode( 'Please select a few logs to delete and try again.' );
-						wp_safe_redirect( admin_url( 'admin.php?page=c4p-main&c4pmessage=' . $message . '&c4pmessageType=warning' ) );
-						exit;
+						if ( wp_safe_redirect( admin_url( 'admin.php?page=c4p-main&c4pmessage=' . $message . '&c4pmessageType=warning' ) ) ) {
+							exit;
+						}
 					}
 				} elseif ( 'c4p-logs--delete-all' === $action && wp_verify_nonce( $nonce, 'bulk-logs' ) ) {
 					$this->helpers->delete_logs( 'all' );
 					$message = rawurlencode( 'All Logs successfully deleted!' );
-					wp_safe_redirect( admin_url( 'admin.php?page=c4p-main&c4pmessage=' . $message . '&c4pmessageType=success' ) );
-					exit;
+					if ( wp_safe_redirect( admin_url( 'admin.php?page=c4p-main&c4pmessage=' . $message . '&c4pmessageType=success' ) ) ) {
+						exit;
+					}
 				} elseif ( 'c4p-logs--export-csv' === $action && wp_verify_nonce( $nonce, 'bulk-logs' ) ) {
 					$this->helpers->export_logs_csv();
 				} elseif ( 'c4p-logs--prune' === $action && wp_verify_nonce( $nonce, 'c4p-logs--prune' ) ) {

--- a/admin/class-helpers.php
+++ b/admin/class-helpers.php
@@ -67,6 +67,8 @@ class Helpers {
 			'redirect_error_code' => 302,
 			'log_ip'              => true,
 			'email_cooldown'      => 3600,
+			'log_retention_count' => 0,
+			'log_retention_days'  => 0,
 		);
 	}
 
@@ -227,6 +229,58 @@ class Helpers {
 			$result = $wpdb->query( $query ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
 		}
 		return $result;
+	}
+
+	/**
+	 * Returns the total number of rows in the logs table.
+	 *
+	 * @since 3.14.0
+	 * @return int Total log row count.
+	 */
+	public function get_logs_count(): int {
+		global $wpdb;
+		$result = $wpdb->get_var( 'SELECT COUNT(*) FROM ' . $wpdb->prefix . $this->table_logs ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+		return (int) $result;
+	}
+
+	/**
+	 * Prunes log entries according to the configured retention settings.
+	 *
+	 * Two independent passes are run:
+	 *   1. Count pass: if log_retention_count > 0 and the table exceeds that cap,
+	 *      the oldest rows (by `created` timestamp) are deleted until only
+	 *      log_retention_count rows remain.
+	 *   2. Age pass: if log_retention_days > 0, all rows older than that many days
+	 *      are deleted.
+	 *
+	 * Returns the total number of rows deleted across both passes.
+	 *
+	 * @since 3.14.0
+	 * @return int Total rows deleted.
+	 */
+	public function prune_logs(): int {
+		global $wpdb;
+		$options  = $this->get_settings();
+		$deleted  = 0;
+		$table    = $wpdb->prefix . $this->table_logs;
+
+		$max_count = isset( $options['log_retention_count'] ) ? (int) $options['log_retention_count'] : 0;
+		if ( $max_count > 0 ) {
+			$total  = $this->get_logs_count();
+			$excess = $total - $max_count;
+			if ( $excess > 0 ) {
+				$query    = $wpdb->prepare( 'DELETE FROM ' . $table . ' ORDER BY created ASC LIMIT %d', $excess ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+				$deleted += (int) $wpdb->query( $query ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+			}
+		}
+
+		$max_days = isset( $options['log_retention_days'] ) ? (int) $options['log_retention_days'] : 0;
+		if ( $max_days > 0 ) {
+			$query    = $wpdb->prepare( 'DELETE FROM ' . $table . ' WHERE created < DATE_SUB(NOW(), INTERVAL %d DAY)', $max_days ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			$deleted += (int) $wpdb->query( $query ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+		}
+
+		return $deleted;
 	}
 
 	/**

--- a/admin/views/logs.php
+++ b/admin/views/logs.php
@@ -12,6 +12,7 @@ $helpers     = Helpers::singleton();
 $options     = $helpers->get_settings();
 $total_count = $helpers->get_logs_count();
 $max_count   = isset( $options['log_retention_count'] ) ? (int) $options['log_retention_count'] : 0;
+$max_days    = isset( $options['log_retention_days'] ) ? (int) $options['log_retention_days'] : 0;
 
 ?>
 
@@ -50,11 +51,13 @@ $max_count   = isset( $options['log_retention_count'] ) ? (int) $options['log_re
 		</div>
 	<?php endif; ?>
 
+	<?php if ( $max_count > 0 || $max_days > 0 ) : ?>
 	<p>
 		<a href="<?php echo esc_url( wp_nonce_url( admin_url( 'admin.php?page=c4p-main&action=c4p-logs--prune' ), 'c4p-logs--prune' ) ); ?>" class="button">
 			<?php esc_html_e( 'Prune Logs Now', 'custom-404-pro' ); ?>
 		</a>
 	</p>
+	<?php endif; ?>
 
 	<form id="form_logs" method="GET">
 		<!-- For plugins, we also need to ensure that the form posts back to our current page -->

--- a/admin/views/logs.php
+++ b/admin/views/logs.php
@@ -20,10 +20,15 @@ $max_count   = isset( $options['log_retention_count'] ) ? (int) $options['log_re
 
 	<p>
 		<?php
-		/* translators: %d: number of log rows */
-		printf( esc_html__( 'Total log entries: %d', 'custom-404-pro' ), $total_count );
+		echo esc_html(
+			sprintf(
+				/* translators: %d: number of log rows */
+				__( 'Total log entries: %d', 'custom-404-pro' ),
+				(int) $total_count
+			)
+		);
 		if ( $max_count > 0 ) {
-			echo ' / ' . esc_html( $max_count );
+			echo ' / ' . (int) $max_count;
 		}
 		?>
 	</p>
@@ -32,11 +37,13 @@ $max_count   = isset( $options['log_retention_count'] ) ? (int) $options['log_re
 		<div class="notice notice-warning inline">
 			<p>
 				<?php
-				printf(
-					/* translators: 1: current log count, 2: max log count */
-					esc_html__( 'Log table is at %1$d of %2$d rows (90%% threshold reached). Consider pruning or raising the Max Log Count setting.', 'custom-404-pro' ),
-					$total_count,
-					$max_count
+				echo esc_html(
+					sprintf(
+						/* translators: 1: current log count, 2: max log count */
+						__( 'Log table is at %1$d of %2$d rows (90%% threshold reached). Consider pruning or raising the Max Log Count setting.', 'custom-404-pro' ),
+						(int) $total_count,
+						(int) $max_count
+					)
 				);
 				?>
 			</p>

--- a/admin/views/logs.php
+++ b/admin/views/logs.php
@@ -5,13 +5,50 @@
  * @package Custom_404_Pro
  */
 
-$logs_table = new LogsClass();
+$logs_table  = new LogsClass();
 $logs_table->prepare_items();
+
+$helpers     = Helpers::singleton();
+$options     = $helpers->get_settings();
+$total_count = $helpers->get_logs_count();
+$max_count   = isset( $options['log_retention_count'] ) ? (int) $options['log_retention_count'] : 0;
 
 ?>
 
 <div class="wrap">
 	<h2>Logs</h2>
+
+	<p>
+		<?php
+		/* translators: %d: number of log rows */
+		printf( esc_html__( 'Total log entries: %d', 'custom-404-pro' ), $total_count );
+		if ( $max_count > 0 ) {
+			echo ' / ' . esc_html( $max_count );
+		}
+		?>
+	</p>
+
+	<?php if ( $max_count > 0 && $total_count >= $max_count * 0.9 ) : ?>
+		<div class="notice notice-warning inline">
+			<p>
+				<?php
+				printf(
+					/* translators: 1: current log count, 2: max log count */
+					esc_html__( 'Log table is at %1$d of %2$d rows (90%% threshold reached). Consider pruning or raising the Max Log Count setting.', 'custom-404-pro' ),
+					$total_count,
+					$max_count
+				);
+				?>
+			</p>
+		</div>
+	<?php endif; ?>
+
+	<p>
+		<a href="<?php echo esc_url( wp_nonce_url( admin_url( 'admin.php?page=c4p-main&action=c4p-logs--prune' ), 'c4p-logs--prune' ) ); ?>" class="button">
+			<?php esc_html_e( 'Prune Logs Now', 'custom-404-pro' ); ?>
+		</a>
+	</p>
+
 	<form id="form_logs" method="GET">
 		<!-- For plugins, we also need to ensure that the form posts back to our current page -->
 		<input type="hidden" name="page" value="<?php echo esc_attr( sanitize_text_field( wp_unslash( $_REQUEST['page'] ?? '' ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended ?>" />

--- a/admin/views/settings-general.php
+++ b/admin/views/settings-general.php
@@ -12,6 +12,8 @@ $logging_enabled     = $options['logging_enabled'] ?? false;
 $redirect_error_code = isset( $options['redirect_error_code'] ) ? (int) $options['redirect_error_code'] : 302;
 $log_ip              = $options['log_ip'] ?? true;
 $email_cooldown      = isset( $options['email_cooldown'] ) ? (int) $options['email_cooldown'] : 3600;
+$log_retention_count = isset( $options['log_retention_count'] ) ? (int) $options['log_retention_count'] : 0;
+$log_retention_days  = isset( $options['log_retention_days'] ) ? (int) $options['log_retention_days'] : 0;
 ?>
 <div class="wrap">
 	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
@@ -81,6 +83,24 @@ $email_cooldown      = isset( $options['email_cooldown'] ) ? (int) $options['ema
 					</select>
 					<p class="description">
 						When a 404 occurs and a redirect mode has been set, it will be performed using this status code.
+					</p>
+				</td>
+			</tr>
+			<tr>
+				<th>Max Log Count</th>
+				<td>
+					<input type="number" name="log_retention_count" value="<?php echo esc_attr( $log_retention_count ); ?>" min="0" step="1" />
+					<p class="description">
+						Maximum number of log rows to keep. When the table exceeds this limit, the oldest rows are deleted automatically during the daily cleanup. Set to <b>0</b> to disable (no limit).
+					</p>
+				</td>
+			</tr>
+			<tr>
+				<th>Max Log Age (days)</th>
+				<td>
+					<input type="number" name="log_retention_days" value="<?php echo esc_attr( $log_retention_days ); ?>" min="0" step="1" />
+					<p class="description">
+						Delete log entries older than this many days during the daily cleanup. Set to <b>0</b> to disable (keep forever).
 					</p>
 				</td>
 			</tr>

--- a/custom-404-pro.php
+++ b/custom-404-pro.php
@@ -3,7 +3,7 @@
  * Plugin Name: Custom 404 Pro
  * Plugin URI: https://wordpress.org/plugins/custom-404-pro/
  * Description: Override the default 404 page with any page or a custom URL from the Admin Panel.
- * Version: 3.13.0
+ * Version: 3.14.0
  * Author: Kunal Nagar
  * Author URI: https://www.kunalnagar.in
  * License: GPL-2.0+
@@ -18,7 +18,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'CUSTOM_404_PRO_VERSION', '3.13.0' );
+define( 'CUSTOM_404_PRO_VERSION', '3.14.0' );
 
 /**
  * Runs on plugin activation.

--- a/includes/class-activateclass.php
+++ b/includes/class-activateclass.php
@@ -23,6 +23,11 @@ class ActivateClass {
 		if ( defined( 'CUSTOM_404_PRO_VERSION' ) ) {
 			update_option( 'custom_404_pro_db_version', CUSTOM_404_PRO_VERSION );
 		}
+
+		// Schedule the daily log-pruning cron event if it is not already registered.
+		if ( ! wp_next_scheduled( 'custom_404_pro_prune_logs' ) ) {
+			wp_schedule_event( time(), 'daily', 'custom_404_pro_prune_logs' );
+		}
 	}
 
 	/**

--- a/includes/class-deactivateclass.php
+++ b/includes/class-deactivateclass.php
@@ -15,6 +15,8 @@ class DeactivateClass {
 	 *
 	 * Unschedules the daily log-pruning cron event. On multisite, this fires
 	 * for the main site only; per-site events on sub-sites will expire naturally.
+	 *
+	 * @since 3.14.0
 	 */
 	public static function deactivate() {
 		$timestamp = wp_next_scheduled( 'custom_404_pro_prune_logs' );

--- a/includes/class-deactivateclass.php
+++ b/includes/class-deactivateclass.php
@@ -12,8 +12,14 @@ class DeactivateClass {
 
 	/**
 	 * Runs on plugin deactivation.
+	 *
+	 * Unschedules the daily log-pruning cron event. On multisite, this fires
+	 * for the main site only; per-site events on sub-sites will expire naturally.
 	 */
 	public static function deactivate() {
-		// Nothing to do here.
+		$timestamp = wp_next_scheduled( 'custom_404_pro_prune_logs' );
+		if ( $timestamp ) {
+			wp_unschedule_event( $timestamp, 'custom_404_pro_prune_logs' );
+		}
 	}
 }

--- a/includes/class-pluginclass.php
+++ b/includes/class-pluginclass.php
@@ -79,5 +79,6 @@ class PluginClass {
 		add_action( 'admin_notices', array( $this->plugin_admin, 'custom_404_pro_notices' ) );
 		add_action( 'admin_post_form-settings-global-redirect', array( $this->plugin_admin, 'form_settings_global_redirect' ) );
 		add_action( 'admin_post_form-settings-general', array( $this->plugin_admin, 'form_settings_general' ) );
+		add_action( 'custom_404_pro_prune_logs', array( $this->plugin_admin, 'run_scheduled_log_prune' ) );
 	}
 }

--- a/includes/class-pluginclass.php
+++ b/includes/class-pluginclass.php
@@ -53,6 +53,9 @@ class PluginClass {
 		}
 		include_once plugin_dir_path( __FILE__ ) . 'class-activateclass.php';
 		ActivateClass::maybe_migrate_legacy_options();
+		if ( ! wp_next_scheduled( 'custom_404_pro_prune_logs' ) ) {
+			wp_schedule_event( time(), 'daily', 'custom_404_pro_prune_logs' );
+		}
 		if ( defined( 'CUSTOM_404_PRO_VERSION' ) ) {
 			update_option( 'custom_404_pro_db_version', CUSTOM_404_PRO_VERSION );
 		}

--- a/includes/class-uninstallclass.php
+++ b/includes/class-uninstallclass.php
@@ -43,6 +43,7 @@ class UninstallClass {
 		delete_option( Helpers::OPTION_KEY );
 		delete_option( 'custom_404_pro_db_version' );
 		delete_transient( 'custom_404_pro_email_cooldown' );
+		wp_unschedule_hook( 'custom_404_pro_prune_logs' );
 
 		// Drop the logs table.
 		$table_logs = $wpdb->prefix . 'custom_404_pro_logs';

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.me/kunalnagar88/10
 Tags: 404, redirect, custom 404, error page, logging
 Requires at least: 3.0.1
 Tested up to: 6.9.4
-Stable tag: 3.13.0
+Stable tag: 3.14.0
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -31,7 +31,7 @@ When logging is enabled, the plugin records every 404 hit to a database table so
 * User agent
 * Timestamp
 
-Logs are searchable and can be deleted individually, in bulk, or all at once. They can also be exported as a CSV file.
+Logs are searchable and can be deleted individually, in bulk, or all at once. They can also be exported as a CSV file. A configurable retention policy lets you automatically cap the table by row count, by age, or both — with a daily background cleanup and an on-demand Prune Now button.
 
 = Email Notifications =
 
@@ -81,6 +81,9 @@ Please open an issue on [GitHub](https://github.com/kunalnagar/custom-404-pro/is
 3. General settings — logging, email notifications, IP recording, and redirect status code
 
 == Changelog ==
+
+= 3.14.0 =
+* Add configurable log retention policy: cap by row count, by age (days), or both. Includes a daily WP-Cron cleanup job and an on-demand Prune Logs Now button on the Logs page.
 
 = 3.13.0 =
 * Add configurable email notification cooldown to prevent inbox flooding on high 404 traffic (15 min / 30 min / 1 hr / 6 hr / 24 hr)

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -60,10 +60,26 @@ class HelpersTest extends TestCase {
 	 */
 	public function test_defaults_contains_all_required_keys() {
 		$helpers  = new Helpers();
-		$required = array( 'mode', 'mode_page', 'mode_url', 'send_email', 'logging_enabled', 'redirect_error_code', 'log_ip', 'email_cooldown' );
+		$required = array( 'mode', 'mode_page', 'mode_url', 'send_email', 'logging_enabled', 'redirect_error_code', 'log_ip', 'email_cooldown', 'log_retention_count', 'log_retention_days' );
 		foreach ( $required as $key ) {
 			$this->assertArrayHasKey( $key, $helpers->defaults(), "defaults() should contain key '{$key}'." );
 		}
+	}
+
+	/**
+	 * Asserts that log_retention_count defaults to 0 (disabled).
+	 */
+	public function test_defaults_log_retention_count_is_zero() {
+		$helpers = new Helpers();
+		$this->assertSame( 0, $helpers->defaults()['log_retention_count'] );
+	}
+
+	/**
+	 * Asserts that log_retention_days defaults to 0 (disabled).
+	 */
+	public function test_defaults_log_retention_days_is_zero() {
+		$helpers = new Helpers();
+		$this->assertSame( 0, $helpers->defaults()['log_retention_days'] );
 	}
 
 	/**

--- a/tests/integration/HelpersDbTest.php
+++ b/tests/integration/HelpersDbTest.php
@@ -152,4 +152,88 @@ class C404P_Integration_HelpersDbTest extends WP_UnitTestCase {
 		$count = (int) $wpdb->get_var( 'SELECT COUNT(*) FROM ' . $wpdb->prefix . $this->helpers->table_logs ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
 		$this->assertSame( 1, $count );
 	}
+
+	// -------------------------------------------------------------------------
+	// Log retention helpers
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Inserts a log row with a backdated `created` timestamp.
+	 *
+	 * @param string $path     Request path for the log entry.
+	 * @param int    $days_ago How many days ago to backdate the entry.
+	 */
+	private function make_old_log( string $path, int $days_ago ) {
+		global $wpdb;
+		$query = $wpdb->prepare(
+			'INSERT INTO ' . $wpdb->prefix . $this->helpers->table_logs . ' (ip, path, referer, user_agent, created) VALUES (%s, %s, %s, %s, DATE_SUB(NOW(), INTERVAL %d DAY))', // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			'127.0.0.1',
+			$path,
+			'',
+			'PHPUnit',
+			$days_ago
+		);
+		$wpdb->query( $query ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+	}
+
+	// -------------------------------------------------------------------------
+	// get_logs_count()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * get_logs_count() should return the total number of rows in the table.
+	 */
+	public function test_get_logs_count_returns_correct_total() {
+		$this->helpers->create_logs( array( $this->make_log( '/a' ), $this->make_log( '/b' ) ), false );
+		$this->assertSame( 2, $this->helpers->get_logs_count() );
+	}
+
+	// -------------------------------------------------------------------------
+	// prune_logs()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * prune_logs() should be a no-op when both retention settings are 0.
+	 */
+	public function test_prune_logs_is_noop_when_both_settings_are_zero() {
+		$this->helpers->update_settings( array( 'log_retention_count' => 0, 'log_retention_days' => 0 ) );
+		$this->helpers->create_logs( array( $this->make_log( '/a' ), $this->make_log( '/b' ), $this->make_log( '/c' ) ), false );
+		$deleted = $this->helpers->prune_logs();
+		$this->assertSame( 0, $deleted );
+		$this->assertSame( 3, $this->helpers->get_logs_count() );
+	}
+
+	/**
+	 * prune_logs() should delete the oldest rows when the count cap is exceeded.
+	 */
+	public function test_prune_logs_deletes_oldest_rows_when_count_limit_exceeded() {
+		$this->helpers->update_settings( array( 'log_retention_count' => 2, 'log_retention_days' => 0 ) );
+		$this->helpers->create_logs( array( $this->make_log( '/a' ), $this->make_log( '/b' ), $this->make_log( '/c' ) ), false );
+		$deleted = $this->helpers->prune_logs();
+		$this->assertSame( 1, $deleted );
+		$this->assertSame( 2, $this->helpers->get_logs_count() );
+	}
+
+	/**
+	 * prune_logs() should delete rows older than the configured age limit.
+	 */
+	public function test_prune_logs_deletes_rows_older_than_age_limit() {
+		$this->helpers->update_settings( array( 'log_retention_count' => 0, 'log_retention_days' => 30 ) );
+		$this->make_old_log( '/old-a', 31 );
+		$this->make_old_log( '/old-b', 35 );
+		$this->helpers->create_logs( array( $this->make_log( '/recent' ) ), false );
+		$deleted = $this->helpers->prune_logs();
+		$this->assertSame( 2, $deleted );
+		$this->assertSame( 1, $this->helpers->get_logs_count() );
+	}
+
+	/**
+	 * prune_logs() should return 0 when the count is within the configured limit.
+	 */
+	public function test_prune_logs_returns_zero_when_count_within_limit() {
+		$this->helpers->update_settings( array( 'log_retention_count' => 10, 'log_retention_days' => 0 ) );
+		$this->helpers->create_logs( array( $this->make_log( '/a' ), $this->make_log( '/b' ) ), false );
+		$deleted = $this->helpers->prune_logs();
+		$this->assertSame( 0, $deleted );
+	}
 }


### PR DESCRIPTION
## Summary

- Adds two independent log retention axes: **Max Log Count** (cap by row count) and **Max Log Age** (cap by age in days). Both default to `0` (disabled) — zero behaviour change for existing users.
- Daily WP-Cron event (`custom_404_pro_prune_logs`) runs both passes automatically. Scheduled on activation, unscheduled on deactivation and uninstall.
- On-demand **Prune Logs Now** button on the Logs page for immediate cleanup.
- Log count stat and a 90%-threshold warning notice displayed on the Logs page.
- Two new settings fields in the General tab with `absint(wp_unslash())` sanitization.

## Test plan

- [ ] Unit tests: `composer test` — 36/36 pass
- [ ] Integration tests: `composer test:integration` — 29/29 pass (5 new prune tests)
- [ ] Verify `Max Log Count = 5` with 6+ rows → Prune Now deletes the oldest row
- [ ] Verify `Max Log Age = 1` with a row inserted yesterday → daily cron or Prune Now removes it
- [ ] Verify warning notice appears on Logs page when count ≥ 90% of the cap
- [ ] Verify deactivation unschedules the cron event (`wp cron event list`)
- [ ] Verify uninstall removes the cron hook and all plugin data cleanly