### PR TITLE
feat: add full i18n support and ship .pot translation template (v3.15.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,36 @@ jobs:
         run: composer install --no-progress
       - name: Run PHPUnit
         run: composer test
+
+  validate-translations:
+    name: Validate Translation Files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install gettext tools
+        run: sudo apt-get install -y gettext
+      - name: Validate .po format specifiers
+        run: |
+          shopt -s nullglob
+          po_files=(languages/*.po)
+          if [ ${#po_files[@]} -eq 0 ]; then
+            echo "No .po files found, skipping."
+            exit 0
+          fi
+          for f in "${po_files[@]}"; do
+            echo "Checking format specifiers: $f"
+            msgfmt --check-format -o /dev/null "$f"
+          done
+      - name: Scan for dangerous content in translations
+        run: |
+          shopt -s nullglob
+          po_files=(languages/*.po)
+          if [ ${#po_files[@]} -eq 0 ]; then
+            echo "No .po files found, skipping."
+            exit 0
+          fi
+          if grep -h "^msgstr" "${po_files[@]}" | grep -iE "<script|javascript:|onerror=|onload=|<iframe|eval\("; then
+            echo "ERROR: Potentially dangerous content found in translation msgstr entries."
+            exit 1
+          fi
+          echo "No dangerous patterns found."

--- a/README.md
+++ b/README.md
@@ -112,6 +112,33 @@ You can disable IP logging with the **Log IP** checkbox under General settings. 
 
 ---
 
+## Contributing Translations
+
+All user-facing strings in the plugin are wrapped in WordPress i18n functions and use the text domain `custom-404-pro`. A Gettext template file (`languages/custom-404-pro.pot`) is shipped with every release.
+
+### Creating a new translation
+
+1. Copy `languages/custom-404-pro.pot` and rename it using the WordPress locale code, e.g. `languages/custom-404-pro-fr_FR.po`.
+2. Open the `.po` file in [Poedit](https://poedit.net/) or [Loco Translate](https://wordpress.org/plugins/loco-translate/) and fill in the `msgstr` fields.
+3. Save — Poedit automatically compiles the `.mo` binary alongside the `.po`. If using a text editor, compile manually: `msgfmt custom-404-pro-fr_FR.po -o custom-404-pro-fr_FR.mo`
+4. Open a pull request adding both the `.po` and `.mo` files to the `languages/` directory.
+
+### Updating the .pot template
+
+If you add new translatable strings, regenerate the template (requires a running [wp-env](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/) environment):
+
+```bash
+composer makepot
+```
+
+### Security note for reviewers
+
+All translation PRs run through a CI job (`validate-translations`) that:
+- Validates format specifiers with `msgfmt --check-format` (prevents runtime `sprintf()` errors if a translator omits `%d` or similar)
+- Scans `msgstr` lines for dangerous patterns (`<script`, `javascript:`, `onerror=`, `<iframe`, `eval(`)
+
+---
+
 ## Support
 
 Open an issue on [GitHub](https://github.com/kunalnagar/custom-404-pro/issues). The WordPress.org support forum is not monitored.
@@ -129,6 +156,9 @@ Like the plugin? [Buy me a coffee via PayPal](https://www.paypal.me/kunalnagar/1
 ## Changelog
 
 See [WordPress.org changelog](https://wordpress.org/plugins/custom-404-pro/changelog/) for the full history.
+
+### 3.15.0
+- Add full translation support: all user-facing strings are now wrapped in i18n functions and a `.pot` template is shipped with the plugin. Includes a CI job to validate `.po` files contributed by translators.
 
 ### 3.14.1
 - Fix page redirect using stale post GUID instead of current permalink, causing silent redirect failures on sites with changed domains, HTTP→HTTPS migrations, or staging-to-production deployments.

--- a/README.md
+++ b/README.md
@@ -114,28 +114,46 @@ You can disable IP logging with the **Log IP** checkbox under General settings. 
 
 ## Contributing Translations
 
-All user-facing strings in the plugin are wrapped in WordPress i18n functions and use the text domain `custom-404-pro`. A Gettext template file (`languages/custom-404-pro.pot`) is shipped with every release.
+All user-facing strings use the text domain `custom-404-pro`. A Gettext template (`languages/custom-404-pro.pot`) is shipped with every release.
 
-### Creating a new translation
+### Via translate.wordpress.org (recommended)
+
+The easiest path — no git, no tooling, just a browser:
+
+1. Create or log in to a [WordPress.org account](https://login.wordpress.org/).
+2. Go to [translate.wordpress.org/projects/wp-plugins/custom-404-pro/](https://translate.wordpress.org/projects/wp-plugins/custom-404-pro/).
+3. Select your locale and click **Translate**.
+4. Submit suggestions for any untranslated strings.
+5. A Translation Editor reviews and approves. Once a locale reaches **90% translated**, WordPress.org packages it and delivers it automatically to all users running that locale — no pull request needed.
+
+This is the primary channel for community translations and the one most translators already use.
+
+### Via pull request (for developers)
+
+If you want to contribute `.po`/`.mo` files directly to the repository:
 
 1. Copy `languages/custom-404-pro.pot` and rename it using the WordPress locale code, e.g. `languages/custom-404-pro-fr_FR.po`.
-2. Open the `.po` file in [Poedit](https://poedit.net/) or [Loco Translate](https://wordpress.org/plugins/loco-translate/) and fill in the `msgstr` fields.
-3. Save — Poedit automatically compiles the `.mo` binary alongside the `.po`. If using a text editor, compile manually: `msgfmt custom-404-pro-fr_FR.po -o custom-404-pro-fr_FR.mo`
-4. Open a pull request adding both the `.po` and `.mo` files to the `languages/` directory.
+2. Open the `.po` file in [Poedit](https://poedit.net/) and fill in the `msgstr` fields.
+3. Save — Poedit compiles the `.mo` binary automatically. Or compile manually:
+   ```bash
+   msgfmt custom-404-pro-fr_FR.po -o custom-404-pro-fr_FR.mo
+   ```
+4. Open a pull request adding both the `.po` and `.mo` files to `languages/`.
 
 ### Updating the .pot template
 
-If you add new translatable strings, regenerate the template (requires a running [wp-env](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/) environment):
+If you add new translatable strings to the plugin source, regenerate the template. This requires a running [wp-env](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/) environment:
 
 ```bash
+npx wp-env start
 composer makepot
 ```
 
 ### Security note for reviewers
 
-All translation PRs run through a CI job (`validate-translations`) that:
-- Validates format specifiers with `msgfmt --check-format` (prevents runtime `sprintf()` errors if a translator omits `%d` or similar)
-- Scans `msgstr` lines for dangerous patterns (`<script`, `javascript:`, `onerror=`, `<iframe`, `eval(`)
+All translation PRs are checked by the `validate-translations` CI job:
+- `msgfmt --check-format` validates format specifiers — catches cases where a translator removes `%d` or `%s`, which would cause a PHP `sprintf()` error at runtime
+- A grep scan rejects `msgstr` lines containing `<script`, `javascript:`, `onerror=`, `<iframe`, or `eval(` — guarding the handful of description strings rendered via `wp_kses_post( __() )`
 
 ---
 

--- a/admin/class-adminclass.php
+++ b/admin/class-adminclass.php
@@ -29,10 +29,10 @@ class AdminClass {
 	 */
 	public function create_menu() {
 		if ( current_user_can( 'manage_options' ) ) {
-			add_menu_page( 'Custom 404 Pro', 'Custom 404 Pro', 'manage_options', 'c4p-main', array( $this, 'page_logs' ), 'dashicons-chart-bar' );
-			add_submenu_page( 'c4p-main', 'Logs', 'Logs', 'manage_options', 'c4p-main', array( $this, 'page_logs' ) );
-			add_submenu_page( 'c4p-main', 'Settings', 'Settings', 'manage_options', 'c4p-settings', array( $this, 'page_settings' ) );
-			add_submenu_page( 'c4p-main', 'About', 'About', 'manage_options', 'c4p-about', array( $this, 'page_about' ) );
+			add_menu_page( esc_html__( 'Custom 404 Pro', 'custom-404-pro' ), esc_html__( 'Custom 404 Pro', 'custom-404-pro' ), 'manage_options', 'c4p-main', array( $this, 'page_logs' ), 'dashicons-chart-bar' );
+			add_submenu_page( 'c4p-main', esc_html__( 'Logs', 'custom-404-pro' ), esc_html__( 'Logs', 'custom-404-pro' ), 'manage_options', 'c4p-main', array( $this, 'page_logs' ) );
+			add_submenu_page( 'c4p-main', esc_html__( 'Settings', 'custom-404-pro' ), esc_html__( 'Settings', 'custom-404-pro' ), 'manage_options', 'c4p-settings', array( $this, 'page_settings' ) );
+			add_submenu_page( 'c4p-main', esc_html__( 'About', 'custom-404-pro' ), esc_html__( 'About', 'custom-404-pro' ), 'manage_options', 'c4p-about', array( $this, 'page_about' ) );
 		}
 	}
 
@@ -119,7 +119,7 @@ class AdminClass {
 			$page = isset( $_POST['mode_page'] ) ? sanitize_text_field( wp_unslash( $_POST['mode_page'] ) ) : '';
 			$url  = isset( $_POST['mode_url'] ) ? sanitize_text_field( wp_unslash( $_POST['mode_url'] ) ) : '';
 			self::update_mode( $mode, $page, $url );
-			$message = rawurlencode( 'Saved!' );
+			$message = rawurlencode( __( 'Saved!', 'custom-404-pro' ) );
 			if ( wp_safe_redirect( admin_url( 'admin.php?page=c4p-settings&tab=global-redirect&c4pmessage=' . $message . '&c4pmessageType=success' ) ) ) {
 				exit;
 			}
@@ -154,7 +154,7 @@ class AdminClass {
 					'log_retention_days'  => $log_retention_days,
 				)
 			);
-			$message = rawurlencode( 'Saved!' );
+			$message = rawurlencode( __( 'Saved!', 'custom-404-pro' ) );
 			if ( wp_safe_redirect( admin_url( 'admin.php?page=c4p-settings&tab=general&c4pmessage=' . $message . '&c4pmessageType=success' ) ) ) {
 				exit;
 			}
@@ -173,19 +173,19 @@ class AdminClass {
 					if ( array_key_exists( 'path', $_REQUEST ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 						$path = is_array( $_REQUEST['path'] ) ? array_map( 'absint', $_REQUEST['path'] ) : absint( $_REQUEST['path'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 						$this->helpers->delete_logs( $path );
-						$message = rawurlencode( 'Log(s) successfully deleted!' );
+						$message = rawurlencode( __( 'Log(s) successfully deleted!', 'custom-404-pro' ) );
 						if ( wp_safe_redirect( admin_url( 'admin.php?page=c4p-main&c4pmessage=' . $message . '&c4pmessageType=success' ) ) ) {
 							exit;
 						}
 					} else {
-						$message = rawurlencode( 'Please select a few logs to delete and try again.' );
+						$message = rawurlencode( __( 'Please select a few logs to delete and try again.', 'custom-404-pro' ) );
 						if ( wp_safe_redirect( admin_url( 'admin.php?page=c4p-main&c4pmessage=' . $message . '&c4pmessageType=warning' ) ) ) {
 							exit;
 						}
 					}
 				} elseif ( 'c4p-logs--delete-all' === $action && wp_verify_nonce( $nonce, 'bulk-logs' ) ) {
 					$this->helpers->delete_logs( 'all' );
-					$message = rawurlencode( 'All Logs successfully deleted!' );
+					$message = rawurlencode( __( 'All Logs successfully deleted!', 'custom-404-pro' ) );
 					if ( wp_safe_redirect( admin_url( 'admin.php?page=c4p-main&c4pmessage=' . $message . '&c4pmessageType=success' ) ) ) {
 						exit;
 					}
@@ -193,7 +193,13 @@ class AdminClass {
 					$this->helpers->export_logs_csv();
 				} elseif ( 'c4p-logs--prune' === $action && wp_verify_nonce( $nonce, 'c4p-logs--prune' ) ) {
 					$deleted = $this->helpers->prune_logs();
-					$message = rawurlencode( sprintf( 'Pruned %d log row(s).', $deleted ) );
+					$message = rawurlencode(
+						sprintf(
+							/* translators: %d: number of log rows pruned */
+							_n( 'Pruned %d log row.', 'Pruned %d log rows.', $deleted, 'custom-404-pro' ),
+							$deleted
+						)
+					);
 					if ( wp_safe_redirect( admin_url( 'admin.php?page=c4p-main&c4pmessage=' . $message . '&c4pmessageType=success' ) ) ) {
 						exit;
 					}
@@ -328,32 +334,33 @@ class AdminClass {
 		}
 		$headers[] = 'From: Site Admin <' . $admin_email . '>' . "\r\n";
 		$headers[] = 'Content-Type: text/html; charset=UTF-8';
-		$message   = '<p>Here are the 404 Log Details:</p>';
+		$message   = '<p>' . __( 'Here are the 404 Log Details:', 'custom-404-pro' ) . '</p>';
 		$message  .= '<table>';
 		$message  .= '<tr>';
-		$message  .= '<th>Site</th>';
+		$message  .= '<th>' . __( 'Site', 'custom-404-pro' ) . '</th>';
 		$message  .= '<td>' . $current_site_name . '</td>';
 		$message  .= '</tr>';
 		$message  .= '<tr>';
-		$message  .= '<th>User IP</th>';
+		$message  .= '<th>' . __( 'User IP', 'custom-404-pro' ) . '</th>';
 		$message  .= '<td>' . $ip . '</td>';
 		$message  .= '</tr>';
 		$message  .= '<tr>';
-		$message  .= '<th>404 Path</th>';
+		$message  .= '<th>' . __( '404 Path', 'custom-404-pro' ) . '</th>';
 		$message  .= '<td>' . $path . '</td>';
 		$message  .= '</tr>';
 		$message  .= '<tr>';
-		$message  .= '<th>Referer</th>';
+		$message  .= '<th>' . __( 'Referer', 'custom-404-pro' ) . '</th>';
 		$message  .= '<td>' . $referer . '</td>';
 		$message  .= '</tr>';
 		$message  .= '<tr>';
-		$message  .= '<th>User Agent</th>';
+		$message  .= '<th>' . __( 'User Agent', 'custom-404-pro' ) . '</th>';
 		$message  .= '<td>' . $user_agent . '</td>';
 		$message  .= '</tr>';
 		$message  .= '</table>';
 		wp_mail(
 			$admin_email,
-			'404 Error on Site',
+			/* translators: email subject sent to the site admin when a 404 is logged */
+			__( '404 Error on Site', 'custom-404-pro' ),
 			$message,
 			$headers
 		);

--- a/admin/class-logsclass.php
+++ b/admin/class-logsclass.php
@@ -144,11 +144,11 @@ class LogsClass extends WP_List_Table {
 	public function get_columns() {
 		$columns = array(
 			'cb'         => "<input type='checkbox' />",
-			'ip'         => 'IP',
-			'path'       => 'Path',
-			'referer'    => 'Referer',
-			'user_agent' => 'User Agent',
-			'created'    => 'Created',
+			'ip'         => esc_html__( 'IP', 'custom-404-pro' ),
+			'path'       => esc_html__( 'Path', 'custom-404-pro' ),
+			'referer'    => esc_html__( 'Referer', 'custom-404-pro' ),
+			'user_agent' => esc_html__( 'User Agent', 'custom-404-pro' ),
+			'created'    => esc_html__( 'Created', 'custom-404-pro' ),
 		);
 		return $columns;
 	}
@@ -203,7 +203,7 @@ class LogsClass extends WP_List_Table {
 		$nonce     = wp_create_nonce( 'c4p-logs--delete' );
 		$page_slug = isset( $_REQUEST['page'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['page'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$actions   = array(
-			'c4p-logs--delete' => sprintf( '<a href="?page=%s&action=%s&path=%s&_wpnonce=%s">Delete</a>', esc_html( $page_slug ), 'c4p-logs--delete', $item['id'], $nonce ),
+			'c4p-logs--delete' => sprintf( '<a href="?page=%s&action=%s&path=%s&_wpnonce=%s">%s</a>', esc_html( $page_slug ), 'c4p-logs--delete', $item['id'], $nonce, esc_html__( 'Delete', 'custom-404-pro' ) ),
 		);
 		return sprintf(
 			'%1$s %2$s',
@@ -231,9 +231,9 @@ class LogsClass extends WP_List_Table {
 	 */
 	public function get_bulk_actions() {
 		$actions = array(
-			'c4p-logs--delete'     => 'Delete',
-			'c4p-logs--delete-all' => 'Delete All',
-			'c4p-logs--export-csv' => 'Export All (.csv)',
+			'c4p-logs--delete'     => esc_html__( 'Delete', 'custom-404-pro' ),
+			'c4p-logs--delete-all' => esc_html__( 'Delete All', 'custom-404-pro' ),
+			'c4p-logs--export-csv' => esc_html__( 'Export All (.csv)', 'custom-404-pro' ),
 		);
 		return $actions;
 	}

--- a/admin/views/about.php
+++ b/admin/views/about.php
@@ -20,12 +20,12 @@ $c4p_author_output = wp_kses(
 
 
 <div class="wrap">
-	<h2>Custom 404 Pro Info</h2><br>
+	<h2><?php esc_html_e( 'Custom 404 Pro Info', 'custom-404-pro' ); ?></h2><br>
 	<div id="poststuff">
 		<div id="post-body" class="metabox-holder columns-2">
 			<div id="post-body-content">
 				<div class="postbox">
-					<h3 class="hndle"><span>About the Author</span></h3>
+					<h3 class="hndle"><span><?php esc_html_e( 'About the Author', 'custom-404-pro' ); ?></span></h3>
 					<div class="inside">
 						<div class="c4p-clearfix">
 							<div class="c4p-left">
@@ -42,7 +42,7 @@ $c4p_author_output = wp_kses(
 			</div>
 			<div id="postbox-container-1" class="postbox-container">
 				<div class="postbox">
-					<h3 class="hndle ui-sortable-handle">Like the plugin?</h3>
+					<h3 class="hndle ui-sortable-handle"><?php esc_html_e( 'Like the plugin?', 'custom-404-pro' ); ?></h3>
 					<div class="inside">
 						<div class="misc-pub-section">
 							<form action="https://www.paypal.com/donate" method="post" target="_top">
@@ -56,36 +56,36 @@ $c4p_author_output = wp_kses(
 					</div>
 				</div>
 				<div class="postbox">
-					<h3 class="hndle ui-sortable-handle">Plugin Info</h3>
+					<h3 class="hndle ui-sortable-handle"><?php esc_html_e( 'Plugin Info', 'custom-404-pro' ); ?></h3>
 					<div class="inside">
 						<div class="misc-pub-section">
-							<label>Name:</label>
+							<label><?php esc_html_e( 'Name:', 'custom-404-pro' ); ?></label>
 							<span>
 							<b><?php echo esc_html( $plugin_data['Title'] ); ?></b>
 							</span>
 						</div>
 						<div class="misc-pub-section">
-							<label>Version:</label>
+							<label><?php esc_html_e( 'Version:', 'custom-404-pro' ); ?></label>
 							<span>
 							<b><?php echo esc_html( $plugin_data['Version'] ); ?></b>
 							</span>
 						</div>
 						<div class="misc-pub-section">
-							<label>Author:</label>
+							<label><?php esc_html_e( 'Author:', 'custom-404-pro' ); ?></label>
 							<span>
 							<b><?php echo $c4p_author_output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- already passed through wp_kses() above ?></b>
 							</span>
 						</div>
 						<div class="misc-pub-section">
-							<label>Email:</label>
+							<label><?php esc_html_e( 'Email:', 'custom-404-pro' ); ?></label>
 							<span>
 							<b><a href="mailto:hireme@kunalnagar.in">hireme@kunalnagar.in</a></b>
 							</span>
 						</div>
 						<div class="misc-pub-section">
-							<label>Need help?</label>
+							<label><?php esc_html_e( 'Need help?', 'custom-404-pro' ); ?></label>
 							<span>
-							<b><a href="https://github.com/kunalnagar/custom-404-pro/issues">Create an Issue</a></b>
+							<b><a href="https://github.com/kunalnagar/custom-404-pro/issues"><?php esc_html_e( 'Create an Issue', 'custom-404-pro' ); ?></a></b>
 							</span>
 						</div>
 					</div>

--- a/admin/views/logs.php
+++ b/admin/views/logs.php
@@ -17,7 +17,7 @@ $max_days    = isset( $options['log_retention_days'] ) ? (int) $options['log_ret
 ?>
 
 <div class="wrap">
-	<h2>Logs</h2>
+	<h2><?php esc_html_e( 'Logs', 'custom-404-pro' ); ?></h2>
 
 	<p>
 		<?php
@@ -64,7 +64,7 @@ $max_days    = isset( $options['log_retention_days'] ) ? (int) $options['log_ret
 		<input type="hidden" name="page" value="<?php echo esc_attr( sanitize_text_field( wp_unslash( $_REQUEST['page'] ?? '' ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended ?>" />
 		<!-- Now we can render the completed list table -->
 		<p class="search-box">
-			<label class="screen-reader-text" for="search_id-search-input">Search</label>
+			<label class="screen-reader-text" for="search_id-search-input"><?php esc_html_e( 'Search', 'custom-404-pro' ); ?></label>
 			<input id="search_id-search-input" type="text" name="s" value="
 			<?php
 			if ( array_key_exists( 's', $_GET ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -72,7 +72,7 @@ $max_days    = isset( $options['log_retention_days'] ) ? (int) $options['log_ret
 			}
 			?>
 			" autocomplete="off" />
-			<input id="search-submit" class="button" type="submit" name="" value="Search" />
+			<input id="search-submit" class="button" type="submit" name="" value="<?php echo esc_attr__( 'Search', 'custom-404-pro' ); ?>" />
 		</p>
 		<?php $logs_table->display(); ?>
 	</form>

--- a/admin/views/settings-general.php
+++ b/admin/views/settings-general.php
@@ -20,56 +20,84 @@ $log_retention_days  = isset( $options['log_retention_days'] ) ? (int) $options[
 		<table class="form-table">
 			<tbody>
 			<tr>
-				<th>Email</th>
+				<th><?php esc_html_e( 'Email', 'custom-404-pro' ); ?></th>
 				<td>
 					<input type="checkbox" id="c4p_log_email" name="send_email" <?php echo (bool) $send_email ? 'checked' : ''; ?> />
 					<p class="description">
-						If you check this, <b>and logging is enabled</b>, an email will be sent on every error log on the admin's email account. If you're just starting out, it is recommended you uncheck this. Enable it based on your error volume to avoid flooding of your email inbox.
+						<?php
+						echo wp_kses_post(
+							__(
+								'If you check this, <b>and logging is enabled</b>, an email will be sent on every error log on the admin\'s email account. If you\'re just starting out, it is recommended you uncheck this. Enable it based on your error volume to avoid flooding of your email inbox.',
+								'custom-404-pro'
+							)
+						);
+						?>
 					</p>
 				</td>
 			</tr>
 			<tr>
-				<th>Email Notification Cooldown</th>
+				<th><?php esc_html_e( 'Email Notification Cooldown', 'custom-404-pro' ); ?></th>
 				<td>
 					<select name="email_cooldown">
-						<option value="900" <?php echo 900 === $email_cooldown ? 'selected' : ''; ?>>15 minutes</option>
-						<option value="1800" <?php echo 1800 === $email_cooldown ? 'selected' : ''; ?>>30 minutes</option>
-						<option value="3600" <?php echo 3600 === $email_cooldown ? 'selected' : ''; ?>>1 hour</option>
-						<option value="21600" <?php echo 21600 === $email_cooldown ? 'selected' : ''; ?>>6 hours</option>
-						<option value="86400" <?php echo 86400 === $email_cooldown ? 'selected' : ''; ?>>24 hours</option>
+						<option value="900" <?php echo 900 === $email_cooldown ? 'selected' : ''; ?>><?php esc_html_e( '15 minutes', 'custom-404-pro' ); ?></option>
+						<option value="1800" <?php echo 1800 === $email_cooldown ? 'selected' : ''; ?>><?php esc_html_e( '30 minutes', 'custom-404-pro' ); ?></option>
+						<option value="3600" <?php echo 3600 === $email_cooldown ? 'selected' : ''; ?>><?php esc_html_e( '1 hour', 'custom-404-pro' ); ?></option>
+						<option value="21600" <?php echo 21600 === $email_cooldown ? 'selected' : ''; ?>><?php esc_html_e( '6 hours', 'custom-404-pro' ); ?></option>
+						<option value="86400" <?php echo 86400 === $email_cooldown ? 'selected' : ''; ?>><?php esc_html_e( '24 hours', 'custom-404-pro' ); ?></option>
 					</select>
 					<p class="description">
-						Only applies when <b>Email</b> is enabled. After a notification email is sent, no further emails will be sent for the selected duration. This prevents inbox flooding during bot crawls or traffic spikes.
+						<?php
+						echo wp_kses_post(
+							__(
+								'Only applies when <b>Email</b> is enabled. After a notification email is sent, no further emails will be sent for the selected duration. This prevents inbox flooding during bot crawls or traffic spikes.',
+								'custom-404-pro'
+							)
+						);
+						?>
 					</p>
 				</td>
 			</tr>
 			<tr>
-				<th>Logging Status</th>
+				<th><?php esc_html_e( 'Logging Status', 'custom-404-pro' ); ?></th>
 				<td>
 					<select name="logging_enabled">
 						<option value="enabled" <?php echo (bool) $logging_enabled ? 'selected' : ''; ?>>
-							Enabled
+							<?php esc_html_e( 'Enabled', 'custom-404-pro' ); ?>
 						</option>
 						<option value="disabled" <?php echo ! (bool) $logging_enabled ? 'selected' : ''; ?>>
-							Disabled
+							<?php esc_html_e( 'Disabled', 'custom-404-pro' ); ?>
 						</option>
 					</select>
 					<p class="description">
-						If logging status is <b>Enabled</b>, the plugin will capture logs. If the logging status is <b>Disabled</b>, the plugin will stop capturing logs. Please note that your previous logs will <b>NOT</b> be deleted. You may do so from the <b>Logs</b> page.
+						<?php
+						echo wp_kses_post(
+							__(
+								'If logging status is <b>Enabled</b>, the plugin will capture logs. If the logging status is <b>Disabled</b>, the plugin will stop capturing logs. Please note that your previous logs will <b>NOT</b> be deleted. You may do so from the <b>Logs</b> page.',
+								'custom-404-pro'
+							)
+						);
+						?>
 					</p>
 				</td>
 			</tr>
 			<tr>
-				<th>Log IP</th>
+				<th><?php esc_html_e( 'Log IP', 'custom-404-pro' ); ?></th>
 				<td>
 					<input type="checkbox" id="c4p_log_ip" name="log_ip" <?php echo (bool) $log_ip ? 'checked' : ''; ?> />
 					<p class="description">
-						By default, the IP address of the 404 user agent is captured. If you would like to disable this for privacy reasons, please uncheck this box. When no IP is recorded, it will appear as <b>N/A</b> in the Logs Table as well as the email.
+						<?php
+						echo wp_kses_post(
+							__(
+								'By default, the IP address of the 404 user agent is captured. If you would like to disable this for privacy reasons, please uncheck this box. When no IP is recorded, it will appear as <b>N/A</b> in the Logs Table as well as the email.',
+								'custom-404-pro'
+							)
+						);
+						?>
 					</p>
 				</td>
 			</tr>
 			<tr>
-				<th>Redirect Code</th>
+				<th><?php esc_html_e( 'Redirect Code', 'custom-404-pro' ); ?></th>
 				<td>
 					<select name="redirect_error_code">
 						<option value="301" <?php echo 301 === $redirect_error_code ? 'selected' : ''; ?>>301
@@ -82,25 +110,39 @@ $log_retention_days  = isset( $options['log_retention_days'] ) ? (int) $options[
 						</option>
 					</select>
 					<p class="description">
-						When a 404 occurs and a redirect mode has been set, it will be performed using this status code.
+						<?php esc_html_e( 'When a 404 occurs and a redirect mode has been set, it will be performed using this status code.', 'custom-404-pro' ); ?>
 					</p>
 				</td>
 			</tr>
 			<tr>
-				<th>Max Log Count</th>
+				<th><?php esc_html_e( 'Max Log Count', 'custom-404-pro' ); ?></th>
 				<td>
 					<input type="number" name="log_retention_count" value="<?php echo esc_attr( $log_retention_count ); ?>" min="0" step="1" />
 					<p class="description">
-						Maximum number of log rows to keep. When the table exceeds this limit, the oldest rows are deleted automatically during the daily cleanup. Set to <b>0</b> to disable (no limit).
+						<?php
+						echo wp_kses_post(
+							__(
+								'Maximum number of log rows to keep. When the table exceeds this limit, the oldest rows are deleted automatically during the daily cleanup. Set to <b>0</b> to disable (no limit).',
+								'custom-404-pro'
+							)
+						);
+						?>
 					</p>
 				</td>
 			</tr>
 			<tr>
-				<th>Max Log Age (days)</th>
+				<th><?php esc_html_e( 'Max Log Age (days)', 'custom-404-pro' ); ?></th>
 				<td>
 					<input type="number" name="log_retention_days" value="<?php echo esc_attr( $log_retention_days ); ?>" min="0" step="1" />
 					<p class="description">
-						Delete log entries older than this many days during the daily cleanup. Set to <b>0</b> to disable (keep forever).
+						<?php
+						echo wp_kses_post(
+							__(
+								'Delete log entries older than this many days during the daily cleanup. Set to <b>0</b> to disable (keep forever).',
+								'custom-404-pro'
+							)
+						);
+						?>
 					</p>
 				</td>
 			</tr>
@@ -108,7 +150,7 @@ $log_retention_days  = isset( $options['log_retention_days'] ) ? (int) $options[
 		</table>
 		<p class="submit">
 			<input type="hidden" name="action" value="form-settings-general"/>
-			<input type="submit" name="submit" id="submit" class="button button-primary" value="Save Changes">
+			<input type="submit" name="submit" id="submit" class="button button-primary" value="<?php echo esc_attr__( 'Save Changes', 'custom-404-pro' ); ?>">
 			<?php wp_nonce_field( 'form-settings-general', 'form-settings-general' ); ?>
 		</p>
 	</form>

--- a/admin/views/settings-global-redirect.php
+++ b/admin/views/settings-global-redirect.php
@@ -25,30 +25,44 @@ if ( 'page' === $redirect_mode ) {
 		<table class="form-table">
 			<tbody>
 			<tr>
-				<th>Mode</th>
+				<th><?php esc_html_e( 'Mode', 'custom-404-pro' ); ?></th>
 				<td>
 					<select id="c4p_mode" name="mode">
-						<option value="">None</option>
+						<option value=""><?php esc_html_e( 'None', 'custom-404-pro' ); ?></option>
 						<option value="page" <?php echo ( 'page' === $redirect_mode ) ? 'selected' : ''; ?>>
-							WordPress Page
+							<?php esc_html_e( 'WordPress Page', 'custom-404-pro' ); ?>
 						</option>
 						<option value="url" <?php echo ( 'url' === $redirect_mode ) ? 'selected' : ''; ?>>
-							URL
+							<?php esc_html_e( 'URL', 'custom-404-pro' ); ?>
 						</option>
 					</select>
 					<p class="description">
-						<b>WordPress Page:</b> Select any WordPress page as a redirect page.
+						<?php
+						echo wp_kses_post(
+							__(
+								'<b>WordPress Page:</b> Select any WordPress page as a redirect page.',
+								'custom-404-pro'
+							)
+						);
+						?>
 					</p>
 					<p class="description">
-						<b>URL:</b> Redirect chosen error requests to a specific URL
+						<?php
+						echo wp_kses_post(
+							__(
+								'<b>URL:</b> Redirect chosen error requests to a specific URL',
+								'custom-404-pro'
+							)
+						);
+						?>
 					</p>
 				</td>
 			</tr>
 			<tr id="c4p_page" class="select-page">
-				<th>Select a Page</th>
+				<th><?php esc_html_e( 'Select a Page', 'custom-404-pro' ); ?></th>
 				<td>
 					<select name="mode_page">
-						<option value="">None (Default Error Page)</option>
+						<option value=""><?php esc_html_e( 'None (Default Error Page)', 'custom-404-pro' ); ?></option>
 		<?php foreach ( $wp_pages as $wp_page ) : ?>
 							<option value="<?php echo esc_attr( $wp_page->ID ); ?>" <?php echo ( $wp_page->ID === (int) $redirect_mode_page ) ? 'selected' : ''; ?>>
 			<?php echo esc_html( $wp_page->post_title ); ?>
@@ -56,16 +70,16 @@ if ( 'page' === $redirect_mode ) {
 		<?php endforeach; ?>
 					</select>
 					<p class="description">
-						The Default error page will be replaced by the page you choose in this list.
+						<?php esc_html_e( 'The Default error page will be replaced by the page you choose in this list.', 'custom-404-pro' ); ?>
 					</p>
 				</td>
 			</tr>
 			<tr id="c4p_url" class="select-url">
-				<th>Enter a URL</th>
+				<th><?php esc_html_e( 'Enter a URL', 'custom-404-pro' ); ?></th>
 				<td>
 					<input id="mode_url" name="mode_url" type="url" class="regular-text" value="<?php echo esc_url( $redirect_mode_url ); ?>" autocomplete="off" <?php echo ( ! empty( $redirect_mode_url ) ) ? 'required = "required"' : ''; ?>>
 					<p class="description">
-						Enter a valid URL, for e.g. https://google.com
+						<?php esc_html_e( 'Enter a valid URL, for e.g. https://google.com', 'custom-404-pro' ); ?>
 					</p>
 				</td>
 			</tr>
@@ -73,12 +87,18 @@ if ( 'page' === $redirect_mode ) {
 		</table>
 		<p class="submit">
 			<input type="hidden" name="action" value="form-settings-global-redirect"/>
-			<input type="submit" name="submit" id="submit" class="button button-primary" value="Save Changes">
+			<input type="submit" name="submit" id="submit" class="button button-primary" value="<?php echo esc_attr__( 'Save Changes', 'custom-404-pro' ); ?>">
 			<?php wp_nonce_field( 'form-settings-global-redirect', 'form-settings-global-redirect' ); ?>
 		</p>
 	</form>
 	<p class="description">
-		<b>Note: </b>To revert back to the default setting, please choose <b>None</b> from the list and <b>Save
-			Changes</b>.
+		<?php
+		echo wp_kses_post(
+			__(
+				'<b>Note: </b>To revert back to the default setting, please choose <b>None</b> from the list and <b>Save Changes</b>.',
+				'custom-404-pro'
+			)
+		);
+		?>
 	</p>
 </div>

--- a/admin/views/settings.php
+++ b/admin/views/settings.php
@@ -11,13 +11,13 @@ $active_tab = empty( $c4p_tab ) ? 'global-redirect' : $c4p_tab;
 ?>
 
 <div class="wrap">
-	<h2>Settings</h2>
+	<h2><?php esc_html_e( 'Settings', 'custom-404-pro' ); ?></h2>
 	<h2 class="nav-tab-wrapper">
 		<a href="?page=c4p-settings&tab=global-redirect" class="nav-tab <?php echo ( 'global-redirect' === $active_tab || '' === $active_tab ) ? 'nav-tab-active' : ''; ?>">
-			Redirect
+			<?php esc_html_e( 'Redirect', 'custom-404-pro' ); ?>
 		</a>
 		<a href="?page=c4p-settings&tab=general" class="nav-tab <?php echo 'general' === $active_tab ? 'nav-tab-active' : ''; ?>">
-			General
+			<?php esc_html_e( 'General', 'custom-404-pro' ); ?>
 		</a>
 	</h2>
 </div>

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     "scripts": {
         "lint": "phpcs",
         "test": "phpunit",
-        "test:integration": "phpunit -c phpunit-integration.xml"
+        "test:integration": "phpunit -c phpunit-integration.xml",
+        "makepot": "npx wp-env run cli wp i18n make-pot /var/www/html/wp-content/plugins/custom-404-pro /var/www/html/wp-content/plugins/custom-404-pro/languages/custom-404-pro.pot --domain=custom-404-pro --exclude=vendor,tests,node_modules"
     },
     "config": {
         "allow-plugins": {

--- a/custom-404-pro.php
+++ b/custom-404-pro.php
@@ -3,7 +3,7 @@
  * Plugin Name: Custom 404 Pro
  * Plugin URI: https://wordpress.org/plugins/custom-404-pro/
  * Description: Override the default 404 page with any page or a custom URL from the Admin Panel.
- * Version: 3.14.1
+ * Version: 3.15.0
  * Author: Kunal Nagar
  * Author URI: https://www.kunalnagar.in
  * License: GPL-2.0+
@@ -18,7 +18,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'CUSTOM_404_PRO_VERSION', '3.14.1' );
+define( 'CUSTOM_404_PRO_VERSION', '3.15.0' );
 
 /**
  * Runs on plugin activation.

--- a/languages/custom-404-pro.pot
+++ b/languages/custom-404-pro.pot
@@ -1,0 +1,342 @@
+# Copyright (C) 2026 Kunal Nagar
+# This file is distributed under the GPL-2.0+.
+msgid ""
+msgstr ""
+"Project-Id-Version: Custom 404 Pro 3.15.0\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/custom-404-pro\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2026-04-22T05:47:54+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"X-Generator: WP-CLI 2.12.0\n"
+"X-Domain: custom-404-pro\n"
+
+#. Plugin Name of the plugin
+#: custom-404-pro.php
+#: admin/class-adminclass.php:32
+msgid "Custom 404 Pro"
+msgstr ""
+
+#. Plugin URI of the plugin
+#: custom-404-pro.php
+msgid "https://wordpress.org/plugins/custom-404-pro/"
+msgstr ""
+
+#. Description of the plugin
+#: custom-404-pro.php
+msgid "Override the default 404 page with any page or a custom URL from the Admin Panel."
+msgstr ""
+
+#. Author of the plugin
+#: custom-404-pro.php
+msgid "Kunal Nagar"
+msgstr ""
+
+#. Author URI of the plugin
+#: custom-404-pro.php
+msgid "https://www.kunalnagar.in"
+msgstr ""
+
+#: admin/class-adminclass.php:33
+#: admin/views/logs.php:20
+msgid "Logs"
+msgstr ""
+
+#: admin/class-adminclass.php:34
+#: admin/views/settings.php:14
+msgid "Settings"
+msgstr ""
+
+#: admin/class-adminclass.php:35
+msgid "About"
+msgstr ""
+
+#: admin/class-adminclass.php:122
+#: admin/class-adminclass.php:157
+msgid "Saved!"
+msgstr ""
+
+#: admin/class-adminclass.php:176
+msgid "Log(s) successfully deleted!"
+msgstr ""
+
+#: admin/class-adminclass.php:181
+msgid "Please select a few logs to delete and try again."
+msgstr ""
+
+#: admin/class-adminclass.php:188
+msgid "All Logs successfully deleted!"
+msgstr ""
+
+#. translators: %d: number of log rows pruned
+#: admin/class-adminclass.php:199
+#, php-format
+msgid "Pruned %d log row."
+msgid_plural "Pruned %d log rows."
+msgstr[0] ""
+msgstr[1] ""
+
+#: admin/class-adminclass.php:337
+msgid "Here are the 404 Log Details:"
+msgstr ""
+
+#: admin/class-adminclass.php:340
+msgid "Site"
+msgstr ""
+
+#: admin/class-adminclass.php:344
+msgid "User IP"
+msgstr ""
+
+#: admin/class-adminclass.php:348
+msgid "404 Path"
+msgstr ""
+
+#: admin/class-adminclass.php:352
+#: admin/class-logsclass.php:149
+msgid "Referer"
+msgstr ""
+
+#: admin/class-adminclass.php:356
+#: admin/class-logsclass.php:150
+msgid "User Agent"
+msgstr ""
+
+#. translators: email subject sent to the site admin when a 404 is logged
+#: admin/class-adminclass.php:363
+msgid "404 Error on Site"
+msgstr ""
+
+#: admin/class-logsclass.php:147
+msgid "IP"
+msgstr ""
+
+#: admin/class-logsclass.php:148
+msgid "Path"
+msgstr ""
+
+#: admin/class-logsclass.php:151
+msgid "Created"
+msgstr ""
+
+#: admin/class-logsclass.php:206
+#: admin/class-logsclass.php:234
+msgid "Delete"
+msgstr ""
+
+#: admin/class-logsclass.php:235
+msgid "Delete All"
+msgstr ""
+
+#: admin/class-logsclass.php:236
+msgid "Export All (.csv)"
+msgstr ""
+
+#: admin/views/about.php:23
+msgid "Custom 404 Pro Info"
+msgstr ""
+
+#: admin/views/about.php:28
+msgid "About the Author"
+msgstr ""
+
+#: admin/views/about.php:45
+msgid "Like the plugin?"
+msgstr ""
+
+#: admin/views/about.php:59
+msgid "Plugin Info"
+msgstr ""
+
+#: admin/views/about.php:62
+msgid "Name:"
+msgstr ""
+
+#: admin/views/about.php:68
+msgid "Version:"
+msgstr ""
+
+#: admin/views/about.php:74
+msgid "Author:"
+msgstr ""
+
+#: admin/views/about.php:80
+msgid "Email:"
+msgstr ""
+
+#: admin/views/about.php:86
+msgid "Need help?"
+msgstr ""
+
+#: admin/views/about.php:88
+msgid "Create an Issue"
+msgstr ""
+
+#. translators: %d: number of log rows
+#: admin/views/logs.php:27
+#, php-format
+msgid "Total log entries: %d"
+msgstr ""
+
+#. translators: 1: current log count, 2: max log count
+#: admin/views/logs.php:44
+#, php-format
+msgid "Log table is at %1$d of %2$d rows (90%% threshold reached). Consider pruning or raising the Max Log Count setting."
+msgstr ""
+
+#: admin/views/logs.php:57
+msgid "Prune Logs Now"
+msgstr ""
+
+#: admin/views/logs.php:67
+#: admin/views/logs.php:75
+msgid "Search"
+msgstr ""
+
+#: admin/views/settings-general.php:23
+msgid "Email"
+msgstr ""
+
+#: admin/views/settings-general.php:29
+msgid "If you check this, <b>and logging is enabled</b>, an email will be sent on every error log on the admin's email account. If you're just starting out, it is recommended you uncheck this. Enable it based on your error volume to avoid flooding of your email inbox."
+msgstr ""
+
+#: admin/views/settings-general.php:39
+msgid "Email Notification Cooldown"
+msgstr ""
+
+#: admin/views/settings-general.php:42
+msgid "15 minutes"
+msgstr ""
+
+#: admin/views/settings-general.php:43
+msgid "30 minutes"
+msgstr ""
+
+#: admin/views/settings-general.php:44
+msgid "1 hour"
+msgstr ""
+
+#: admin/views/settings-general.php:45
+msgid "6 hours"
+msgstr ""
+
+#: admin/views/settings-general.php:46
+msgid "24 hours"
+msgstr ""
+
+#: admin/views/settings-general.php:51
+msgid "Only applies when <b>Email</b> is enabled. After a notification email is sent, no further emails will be sent for the selected duration. This prevents inbox flooding during bot crawls or traffic spikes."
+msgstr ""
+
+#: admin/views/settings-general.php:61
+msgid "Logging Status"
+msgstr ""
+
+#: admin/views/settings-general.php:65
+msgid "Enabled"
+msgstr ""
+
+#: admin/views/settings-general.php:68
+msgid "Disabled"
+msgstr ""
+
+#: admin/views/settings-general.php:74
+msgid "If logging status is <b>Enabled</b>, the plugin will capture logs. If the logging status is <b>Disabled</b>, the plugin will stop capturing logs. Please note that your previous logs will <b>NOT</b> be deleted. You may do so from the <b>Logs</b> page."
+msgstr ""
+
+#: admin/views/settings-general.php:84
+msgid "Log IP"
+msgstr ""
+
+#: admin/views/settings-general.php:90
+msgid "By default, the IP address of the 404 user agent is captured. If you would like to disable this for privacy reasons, please uncheck this box. When no IP is recorded, it will appear as <b>N/A</b> in the Logs Table as well as the email."
+msgstr ""
+
+#: admin/views/settings-general.php:100
+msgid "Redirect Code"
+msgstr ""
+
+#: admin/views/settings-general.php:113
+msgid "When a 404 occurs and a redirect mode has been set, it will be performed using this status code."
+msgstr ""
+
+#: admin/views/settings-general.php:118
+msgid "Max Log Count"
+msgstr ""
+
+#: admin/views/settings-general.php:124
+msgid "Maximum number of log rows to keep. When the table exceeds this limit, the oldest rows are deleted automatically during the daily cleanup. Set to <b>0</b> to disable (no limit)."
+msgstr ""
+
+#: admin/views/settings-general.php:134
+msgid "Max Log Age (days)"
+msgstr ""
+
+#: admin/views/settings-general.php:140
+msgid "Delete log entries older than this many days during the daily cleanup. Set to <b>0</b> to disable (keep forever)."
+msgstr ""
+
+#: admin/views/settings-general.php:153
+#: admin/views/settings-global-redirect.php:90
+msgid "Save Changes"
+msgstr ""
+
+#: admin/views/settings-global-redirect.php:28
+msgid "Mode"
+msgstr ""
+
+#: admin/views/settings-global-redirect.php:31
+msgid "None"
+msgstr ""
+
+#: admin/views/settings-global-redirect.php:33
+msgid "WordPress Page"
+msgstr ""
+
+#: admin/views/settings-global-redirect.php:36
+msgid "URL"
+msgstr ""
+
+#: admin/views/settings-global-redirect.php:42
+msgid "<b>WordPress Page:</b> Select any WordPress page as a redirect page."
+msgstr ""
+
+#: admin/views/settings-global-redirect.php:52
+msgid "<b>URL:</b> Redirect chosen error requests to a specific URL"
+msgstr ""
+
+#: admin/views/settings-global-redirect.php:62
+msgid "Select a Page"
+msgstr ""
+
+#: admin/views/settings-global-redirect.php:65
+msgid "None (Default Error Page)"
+msgstr ""
+
+#: admin/views/settings-global-redirect.php:73
+msgid "The Default error page will be replaced by the page you choose in this list."
+msgstr ""
+
+#: admin/views/settings-global-redirect.php:78
+msgid "Enter a URL"
+msgstr ""
+
+#: admin/views/settings-global-redirect.php:82
+msgid "Enter a valid URL, for e.g. https://google.com"
+msgstr ""
+
+#: admin/views/settings-global-redirect.php:97
+msgid "<b>Note: </b>To revert back to the default setting, please choose <b>None</b> from the list and <b>Save Changes</b>."
+msgstr ""
+
+#: admin/views/settings.php:17
+msgid "Redirect"
+msgstr ""
+
+#: admin/views/settings.php:20
+msgid "General"
+msgstr ""

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.me/kunalnagar88/10
 Tags: 404, redirect, custom 404, error page, logging
 Requires at least: 3.0.1
 Tested up to: 6.9.4
-Stable tag: 3.14.1
+Stable tag: 3.15.0
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -81,6 +81,9 @@ Please open an issue on [GitHub](https://github.com/kunalnagar/custom-404-pro/is
 3. General settings — logging, email notifications, IP recording, and redirect status code
 
 == Changelog ==
+
+= 3.15.0 =
+* Add full translation support: all user-facing strings are now wrapped in i18n functions and a .pot template is shipped with the plugin. Includes a CI job to validate .po files contributed by community translators.
 
 = 3.14.1 =
 * Fix page redirect using stale post GUID instead of current permalink, causing silent redirect failures on sites with changed domains, HTTP→HTTPS migrations, or staging-to-production deployments


### PR DESCRIPTION
## Summary

- Wraps all ~55 user-facing strings in i18n functions across 7 PHP files (views + admin classes), using the correct escaping function per output context
- Ships `languages/custom-404-pro.pot` (78 `msgid` entries) generated via `wp i18n make-pot` — this is the template community translators copy to create `.po` files for their locale
- Adds a `validate-translations` CI job that runs `msgfmt --check-format` and a grep-based XSS scan on any contributed `.po` files (no-ops cleanly until a translation PR lands)
- Adds `composer makepot` script for regenerating the template after string changes
- Adds a **Contributing Translations** section to `README.md` documenting the workflow for contributors

## Security

i18n introduces a new attack surface — a translator could embed HTML/JS in a translated string. All output contexts are guarded:

| Context | Function used |
|---------|--------------|
| Echoed HTML text | `esc_html_e()` / `esc_html( sprintf( __() ) )` |
| HTML attribute values | `esc_attr__()` / `esc_attr_e()` |
| Descriptions with `<b>` tags | `wp_kses_post( __() )` |
| WP_List_Table column headers | `esc_html__()` — WP does not escape these |
| WP_List_Table bulk action labels | `esc_html__()` — WP does not escape these |
| Admin menu / page titles | `esc_html__()` — WP doesn't guarantee escaping |
| Email body (`wp_mail`) | `__()` raw — not output to browser |
| Messages via URL query param | `__()` raw — `custom_404_pro_notices()` applies `esc_html()` at display time |

The CI `validate-translations` job adds a second layer: `msgfmt --check-format` blocks format specifier mismatches (prevents runtime `sprintf()` errors) and a grep scan blocks `<script`, `javascript:`, `onerror=`, `<iframe`, and `eval(` in `msgstr` lines.

## Test plan

- [ ] PHPCS passes (`composer lint`) — 15/15 files clean
- [ ] PHPUnit passes (`composer test`) — 36/36 tests pass
- [ ] `.pot` file contains 78 `msgid` entries covering all wrapped strings
- [ ] `validate-translations` CI job no-ops cleanly (no `.po` files yet)
- [ ] Integration tests pass (`composer test:integration`)