### PR TITLE
fix: use get_permalink() instead of post GUID for page redirect (v3.14.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ Like the plugin? [Buy me a coffee via PayPal](https://www.paypal.me/kunalnagar/1
 
 See [WordPress.org changelog](https://wordpress.org/plugins/custom-404-pro/changelog/) for the full history.
 
+### 3.14.1
+- Fix page redirect using stale post GUID instead of current permalink, causing silent redirect failures on sites with changed domains, HTTP→HTTPS migrations, or staging-to-production deployments.
+
 ### 3.14.0
 - Add configurable log retention policy: cap by row count, by age (days), or both. Includes a daily WP-Cron cleanup job and an on-demand Prune Logs Now button on the Logs page.
 

--- a/admin/class-adminclass.php
+++ b/admin/class-adminclass.php
@@ -213,10 +213,10 @@ class AdminClass {
 				self::custom_404_pro_log( $options['send_email'] ?? '', $email_cooldown );
 			}
 			if ( 'page' === ( $options['mode'] ?? '' ) ) {
-				$page_id = $this->resolve_multilingual_page_id( (int) ( $options['mode_page'] ?? 0 ) );
-				$page    = get_post( $page_id );
-				if ( $page ) {
-					if ( wp_safe_redirect( $page->guid, (int) ( $options['redirect_error_code'] ?? 302 ) ) ) {
+				$page_id   = $this->resolve_multilingual_page_id( (int) ( $options['mode_page'] ?? 0 ) );
+				$permalink = get_permalink( $page_id );
+				if ( $permalink ) {
+					if ( wp_safe_redirect( $permalink, (int) ( $options['redirect_error_code'] ?? 302 ) ) ) {
 						exit;
 					}
 				}

--- a/custom-404-pro.php
+++ b/custom-404-pro.php
@@ -3,7 +3,7 @@
  * Plugin Name: Custom 404 Pro
  * Plugin URI: https://wordpress.org/plugins/custom-404-pro/
  * Description: Override the default 404 page with any page or a custom URL from the Admin Panel.
- * Version: 3.14.0
+ * Version: 3.14.1
  * Author: Kunal Nagar
  * Author URI: https://www.kunalnagar.in
  * License: GPL-2.0+
@@ -18,7 +18,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'CUSTOM_404_PRO_VERSION', '3.14.0' );
+define( 'CUSTOM_404_PRO_VERSION', '3.14.1' );
 
 /**
  * Runs on plugin activation.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.me/kunalnagar88/10
 Tags: 404, redirect, custom 404, error page, logging
 Requires at least: 3.0.1
 Tested up to: 6.9.4
-Stable tag: 3.14.0
+Stable tag: 3.14.1
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -81,6 +81,9 @@ Please open an issue on [GitHub](https://github.com/kunalnagar/custom-404-pro/is
 3. General settings — logging, email notifications, IP recording, and redirect status code
 
 == Changelog ==
+
+= 3.14.1 =
+* Fix page redirect using stale post GUID instead of current permalink, causing silent redirect failures on sites with changed domains, HTTP→HTTPS migrations, or staging-to-production deployments
 
 = 3.14.0 =
 * Add configurable log retention policy: cap by row count, by age (days), or both. Includes a daily WP-Cron cleanup job and an on-demand Prune Logs Now button on the Logs page.

--- a/tests/AdminClassTest.php
+++ b/tests/AdminClassTest.php
@@ -35,12 +35,17 @@ class AdminClassTest extends TestCase {
 	}
 
 	/**
-	 * Resets multilingual stubs, filter registry, and transient store before each test.
+	 * Resets multilingual stubs, filter registry, redirect captures, and transient store before each test.
 	 */
 	protected function setUp(): void {
 		parent::setUp();
 		$GLOBALS['_test_filters']        = array();
 		$GLOBALS['_test_transients']     = array();
+		$GLOBALS['_test_options']        = array();
+		$GLOBALS['_test_is_404']         = false;
+		$GLOBALS['_test_permalinks']     = array();
+		$GLOBALS['_test_redirect_url']   = null;
+		$GLOBALS['_test_redirect_status'] = null;
 		$GLOBALS['_pll_get_post_return'] = false;
 		unset( $GLOBALS['_pll_current_language'] );
 		unset( $GLOBALS['_pll_default_language'] );
@@ -148,6 +153,84 @@ class AdminClassTest extends TestCase {
 		$GLOBALS['_pll_get_post_return']  = false; // pll_get_post returns false → no translation.
 		$admin = new AdminClass();
 		$this->assertSame( 20, $this->normalize( $admin, 20 ) );
+	}
+
+	// ------------------------------------------------------------------
+	// custom_404_pro_redirect — page mode
+	// ------------------------------------------------------------------
+
+	/**
+	 * Helper: seed settings into the test options store.
+	 *
+	 * @param array $settings Settings to merge into defaults.
+	 */
+	private function seed_settings( array $settings ): void {
+		$defaults = array(
+			'mode'               => '',
+			'mode_page'          => '0',
+			'mode_url'           => '',
+			'redirect_error_code' => 302,
+			'logging_enabled'    => false,
+			'send_email'         => false,
+			'log_ip'             => true,
+			'email_cooldown'     => HOUR_IN_SECONDS,
+			'max_log_count'      => 0,
+			'max_log_age'        => 0,
+		);
+		update_option( Helpers::OPTION_KEY, array_merge( $defaults, $settings ) );
+	}
+
+	/**
+	 * Asserts that page mode redirects to the URL returned by get_permalink(), not any other value.
+	 */
+	public function test_redirect_page_mode_uses_get_permalink() {
+		$GLOBALS['_test_is_404']          = true;
+		$GLOBALS['_test_permalinks'][42]  = 'https://example.com/custom-404/';
+		$this->seed_settings( array( 'mode' => 'page', 'mode_page' => '42' ) );
+
+		$admin = new AdminClass();
+		$admin->custom_404_pro_redirect();
+
+		$this->assertSame(
+			'https://example.com/custom-404/',
+			$GLOBALS['_test_redirect_url'],
+			'Redirect URL must come from get_permalink(), not post->guid or any other property.'
+		);
+	}
+
+	/**
+	 * Asserts that no redirect fires in page mode when get_permalink() returns false
+	 * (e.g. the configured page ID no longer exists).
+	 */
+	public function test_redirect_page_mode_does_not_redirect_when_permalink_is_false() {
+		$GLOBALS['_test_is_404']         = true;
+		$GLOBALS['_test_permalinks'][99] = false; // page deleted / unpublished
+		$this->seed_settings( array( 'mode' => 'page', 'mode_page' => '99' ) );
+
+		$admin = new AdminClass();
+		$admin->custom_404_pro_redirect();
+
+		$this->assertNull(
+			$GLOBALS['_test_redirect_url'],
+			'No redirect should fire when get_permalink() returns false.'
+		);
+	}
+
+	/**
+	 * Asserts that no redirect fires when the current request is not a 404.
+	 */
+	public function test_redirect_page_mode_does_not_fire_when_not_404() {
+		$GLOBALS['_test_is_404']         = false;
+		$GLOBALS['_test_permalinks'][42] = 'https://example.com/custom-404/';
+		$this->seed_settings( array( 'mode' => 'page', 'mode_page' => '42' ) );
+
+		$admin = new AdminClass();
+		$admin->custom_404_pro_redirect();
+
+		$this->assertNull(
+			$GLOBALS['_test_redirect_url'],
+			'No redirect should fire for non-404 requests.'
+		);
 	}
 
 	// ------------------------------------------------------------------

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -15,6 +15,10 @@ $GLOBALS['_test_actions']                 = array();
 $GLOBALS['_load_plugin_textdomain_calls'] = array();
 $GLOBALS['_test_options']                 = array();
 $GLOBALS['_test_transients']              = array();
+$GLOBALS['_test_is_404']                  = false;
+$GLOBALS['_test_permalinks']              = array();
+$GLOBALS['_test_redirect_url']            = null;
+$GLOBALS['_test_redirect_status']         = null;
 
 // WordPress time constants.
 if ( ! defined( 'MINUTE_IN_SECONDS' ) ) {
@@ -250,6 +254,45 @@ function set_transient( string $transient, $value, int $expiration = 0 ) { // ph
 function delete_transient( string $transient ): bool {
 	unset( $GLOBALS['_test_transients'][ $transient ] );
 	return true;
+}
+
+/**
+ * Stub for WordPress is_404().
+ *
+ * Returns the value of $GLOBALS['_test_is_404']; defaults to false.
+ *
+ * @return bool
+ */
+function is_404(): bool {
+	return $GLOBALS['_test_is_404'] ?? false;
+}
+
+/**
+ * Stub for WordPress get_permalink().
+ *
+ * Returns the value from $GLOBALS['_test_permalinks'][$post_id], or false if not set.
+ *
+ * @param int $post_id Post ID.
+ * @return string|false
+ */
+function get_permalink( $post_id = 0 ) {
+	return $GLOBALS['_test_permalinks'][ $post_id ] ?? false;
+}
+
+/**
+ * Stub for WordPress wp_safe_redirect().
+ *
+ * Captures the redirect URL and status in globals and returns false so that
+ * the gated exit( ) in custom_404_pro_redirect() does not terminate the process.
+ *
+ * @param string $location Redirect URL.
+ * @param int    $status   HTTP status code.
+ * @return bool Always false.
+ */
+function wp_safe_redirect( string $location, int $status = 302 ): bool {
+	$GLOBALS['_test_redirect_url']    = $location;
+	$GLOBALS['_test_redirect_status'] = $status;
+	return false;
 }
 
 require_once dirname( __DIR__ ) . '/admin/class-helpers.php';

--- a/tests/integration/RedirectTest.php
+++ b/tests/integration/RedirectTest.php
@@ -106,6 +106,7 @@ class C404P_Integration_RedirectTest extends WP_UnitTestCase {
 	 */
 	public function allow_test_hosts( $hosts ) {
 		$hosts[] = 'example.com';
+		$hosts[] = 'example.org'; // WP test environment site domain.
 		return $hosts;
 	}
 
@@ -158,9 +159,9 @@ class C404P_Integration_RedirectTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Page mode should redirect to the GUID of the configured WordPress page.
+	 * Page mode should redirect to the current permalink of the configured WordPress page.
 	 */
-	public function test_redirect_sends_page_guid_in_page_mode() {
+	public function test_redirect_page_mode_uses_current_permalink() {
 		$page_id = self::factory()->post->create(
 			array(
 				'post_type'   => 'page',
@@ -168,13 +169,46 @@ class C404P_Integration_RedirectTest extends WP_UnitTestCase {
 				'post_title'  => 'Custom 404 Page',
 			)
 		);
-		$page    = get_post( $page_id );
 
 		$this->helpers->update_settings( array( 'mode' => 'page', 'mode_page' => (string) $page_id ) );
 
 		$this->admin->custom_404_pro_redirect();
 
-		$this->assertSame( $page->guid, $this->redirect_url );
+		$this->assertSame( get_permalink( $page_id ), $this->redirect_url );
+	}
+
+	/**
+	 * Page mode should redirect to the current permalink even when the post GUID
+	 * is stale (e.g. after a domain migration or HTTP→HTTPS upgrade).
+	 *
+	 * This is the regression test for the bug reported against Genesis themes:
+	 * the old code used $page->guid which is never updated after post creation,
+	 * causing wp_safe_redirect() to reject the cross-domain URL silently.
+	 */
+	public function test_redirect_page_mode_uses_permalink_not_stale_guid() {
+		global $wpdb;
+
+		$page_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_title'  => 'Custom 404 Page',
+			)
+		);
+
+		// Simulate a stale GUID left over from a domain migration.
+		$stale_guid = 'http://old-domain.example.com/?page_id=' . $page_id;
+		$wpdb->update( $wpdb->posts, array( 'guid' => $stale_guid ), array( 'ID' => $page_id ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		clean_post_cache( $page_id );
+
+		$this->helpers->update_settings( array( 'mode' => 'page', 'mode_page' => (string) $page_id ) );
+
+		$this->admin->custom_404_pro_redirect();
+
+		$expected_url = get_permalink( $page_id );
+		$this->assertNotNull( $this->redirect_url, 'A redirect should fire in page mode.' );
+		$this->assertSame( $expected_url, $this->redirect_url, 'Redirect should use get_permalink(), not the stale GUID.' );
+		$this->assertNotSame( $stale_guid, $this->redirect_url, 'Redirect must not use the stale GUID.' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Replaces `$page->guid` with `get_permalink($page_id)` in `custom_404_pro_redirect()`

## Root cause

`$post->guid` is WordPress's internal GUID — set once at post creation and **never updated**. It is [explicitly documented](https://developer.wordpress.org/reference/classes/wp_post/) as not guaranteed to be a usable URL. On sites that have:

- changed domains
- migrated from HTTP → HTTPS
- deployed from a staging server to production

…the GUID contains the old/wrong domain. `wp_safe_redirect()` validates the redirect host against the current site and returns `false` when there's a mismatch. Since `exit` is gated on that return value, the redirect silently does nothing and the theme's default 404 page renders instead.

This was reported by a user running a Genesis theme, which is commonly used in agency/migration setups where the GUID mismatch is likely. `get_permalink($page_id)` always returns the current canonical URL and is the correct function to use here.

## Test plan

- [ ] PHPCS passes (`composer lint`)
- [ ] PHPUnit passes (`composer test`) — 36/36
- [ ] On a site where the page GUID doesn't match the live domain (e.g. staging → prod), 404s now correctly redirect to the configured page