### PR TITLE
chore: confirm WordPress 7.0 compatibility (v3.15.1)

### DIFF
--- a/custom-404-pro.php
+++ b/custom-404-pro.php
@@ -3,7 +3,7 @@
  * Plugin Name: Custom 404 Pro
  * Plugin URI: https://wordpress.org/plugins/custom-404-pro/
  * Description: Override the default 404 page with any page or a custom URL from the Admin Panel.
- * Version: 3.15.0
+ * Version: 3.15.1
  * Author: Kunal Nagar
  * Author URI: https://www.kunalnagar.in
  * License: GPL-2.0+
@@ -18,7 +18,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'CUSTOM_404_PRO_VERSION', '3.15.0' );
+define( 'CUSTOM_404_PRO_VERSION', '3.15.1' );
 
 /**
  * Runs on plugin activation.

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: kunalnagar
 Donate link: https://www.paypal.me/kunalnagar88/10
 Tags: 404, redirect, custom 404, error page, logging
 Requires at least: 3.0.1
-Tested up to: 6.9.4
-Stable tag: 3.15.0
+Tested up to: 7.0
+Stable tag: 3.15.1
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -81,6 +81,9 @@ Please open an issue on [GitHub](https://github.com/kunalnagar/custom-404-pro/is
 3. General settings — logging, email notifications, IP recording, and redirect status code
 
 == Changelog ==
+
+= 3.15.1 =
+* Confirm compatibility with WordPress 7.0
 
 = 3.15.0 =
 * Add full translation support: all user-facing strings are now wrapped in i18n functions and a .pot template is shipped with the plugin. Includes a CI job to validate .po files contributed by community translators.


### PR DESCRIPTION
## Summary

- Bumps `Tested up to` in `readme.txt` from `6.9.4` → `7.0`
- Bumps `Stable tag` from `3.15.0` → `3.15.1`
- Bumps plugin `Version` header and `CUSTOM_404_PRO_VERSION` constant to `3.15.1`
- Adds changelog entry for `3.15.1`

No code changes — the plugin uses traditional admin forms and jQuery only. None of WordPress 7.0's breaking changes affect this plugin:

| WP 7.0 Change | Impact |
|---|---|
| Modern admin theme (new default) | None — no `@wordpress/components`, standard form-table markup only |
| Iframed editor | None — no block editor integration |
| PHP 7.2/7.3 dropped | None — `Requires PHP: 7.4` already set |
| AI Client, Connections API, Abilities API | None — not used |

## Test plan

- [ ] Install the plugin on a WordPress 7.0 RC environment
- [ ] Confirm Settings and Logs admin pages render correctly under the Modern theme
- [ ] Confirm 404 redirect fires as expected
- [ ] Confirm no PHP deprecation notices with PHP 8.x