### PR TITLE
Repair Logs table sorting, search and pagination (v3.15.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,12 @@ Like the plugin? [Buy me a coffee via PayPal](https://www.paypal.me/kunalnagar/1
 
 See [WordPress.org changelog](https://wordpress.org/plugins/custom-404-pro/changelog/) for the full history.
 
+### 3.15.3
+- Fix Logs table sorting: sorting by IP, Path, Referer or User Agent produced invalid SQL and returned a database error. Only the Created column sorted correctly.
+- Fix searching and then sorting the Logs table: `ORDER BY` was emitted before `WHERE`, breaking the query.
+- Fix Logs table pagination reading the entire log table into memory on every page view; pagination is now applied in SQL.
+- Escape log values rendered in the Logs table.
+
 ### 3.15.2
 - Confirm compatibility with WordPress 7.1.
 - Declare accurate `Requires at least` (5.0) and `Requires PHP` (7.4) values in the plugin header.

--- a/admin/class-logsclass.php
+++ b/admin/class-logsclass.php
@@ -15,10 +15,39 @@ if ( ! class_exists( 'WP_List_Table' ) ) {
 class LogsClass extends WP_List_Table {
 
 	/**
+	 * Number of log rows shown per page.
+	 *
+	 * @since 3.15.3
+	 * @var int
+	 */
+	const PER_PAGE = 50;
+
+	/**
+	 * Maps an `orderby` query argument to a real database column.
+	 *
+	 * Both the current column keys and the short legacy keys ('i', 'p', 'r', 'u')
+	 * are accepted so that bookmarked sort URLs from older versions keep working.
+	 * Any value outside this map is discarded rather than interpolated into SQL.
+	 *
+	 * @since 3.15.3
+	 * @var array<string, string>
+	 */
+	const SORTABLE_COLUMN_MAP = array(
+		'created'    => 'created',
+		'ip'         => 'ip',
+		'path'       => 'path',
+		'referer'    => 'referer',
+		'user_agent' => 'user_agent',
+		'i'          => 'ip',
+		'p'          => 'path',
+		'r'          => 'referer',
+		'u'          => 'user_agent',
+	);
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
-		global $status, $page;
 		parent::__construct(
 			array(
 				'singular' => 'log',
@@ -40,79 +69,146 @@ class LogsClass extends WP_List_Table {
 
 	/**
 	 * Prepares the list of items for displaying.
+	 *
+	 * The query is assembled in SQL order — WHERE, then ORDER BY, then LIMIT —
+	 * and pagination is applied by the database. Only the rows for the current
+	 * page are ever read into PHP, so the screen stays usable on sites with very
+	 * large log tables.
+	 *
+	 * @since 3.15.3 Pagination moved into SQL; clause order corrected.
 	 */
 	public function prepare_items() {
 		global $wpdb;
-		$columns               = self::get_columns();
+
+		$columns               = $this->get_columns();
 		$hidden                = array();
-		$sortable              = self::get_sortable_columns();
+		$sortable              = $this->get_sortable_columns();
 		$this->_column_headers = array( $columns, $hidden, $sortable );
-		$helpers               = Helpers::singleton();
-		$sql                   = 'SELECT * FROM ' . $wpdb->prefix . $helpers->table_logs;
 
-		if ( array_key_exists( 'orderby', $_GET ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$order_by = sanitize_text_field( wp_unslash( $_GET['orderby'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$order    = isset( $_GET['order'] ) ? strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			if ( ! empty( $order_by ) && ! empty( $order ) ) {
-				$sql = self::manage_sorting( $order_by, $order, $sql );
-			}
-		}
+		$helpers = Helpers::singleton();
+		$table   = $wpdb->prefix . $helpers->table_logs;
 
+		// WHERE must be built first: appending ORDER BY before it is invalid SQL.
+		$where = '';
 		if ( array_key_exists( 's', $_GET ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$search = sanitize_text_field( wp_unslash( $_GET['s'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			if ( ! empty( $search ) ) {
-				$sql = self::manage_search( $search, $sql );
+			if ( '' !== $search ) {
+				$where = $this->build_search_clause( $search );
 			}
 		}
 
-		$sql_data       = $wpdb->get_results( $sql ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
-		$data           = array();
-		$sql_data_count = count( $sql_data );
-		for ( $i = 0; $i < $sql_data_count; $i++ ) {
-			$temp               = array();
-			$temp['id']         = $sql_data[ $i ]->id;
-			$temp['ip']         = sanitize_text_field( $sql_data[ $i ]->ip );
-			$temp['path']       = sanitize_text_field( $sql_data[ $i ]->path );
-			$temp['referer']    = sanitize_text_field( $sql_data[ $i ]->referer );
-			$temp['user_agent'] = sanitize_text_field( $sql_data[ $i ]->user_agent );
-			$temp['created']    = sanitize_text_field( $sql_data[ $i ]->created );
-			array_push( $data, $temp );
+		// Count every matching row so pagination reports the real total.
+		$total_items = (int) $wpdb->get_var( 'SELECT COUNT(*) FROM ' . $table . $where ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+
+		$sql = 'SELECT * FROM ' . $table . $where;
+
+		$order_by = '';
+		$order    = '';
+		if ( array_key_exists( 'orderby', $_GET ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$order_by = sanitize_text_field( wp_unslash( $_GET['orderby'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$order    = isset( $_GET['order'] ) ? sanitize_text_field( wp_unslash( $_GET['order'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		}
-		$per_page     = 50;
-		$current_page = $this->get_pagenum();
-		$total_items  = count( $data );
+		$sql .= $this->build_order_clause( $order_by, $order );
+
+		$per_page     = self::PER_PAGE;
+		$current_page = max( 1, $this->get_pagenum() );
+
 		$this->set_pagination_args(
 			array(
 				'total_items' => $total_items,
 				'per_page'    => $per_page,
 			)
 		);
-		$data        = array_slice( $data, ( ( $current_page - 1 ) * $per_page ), $per_page );
+
+		$sql .= $wpdb->prepare( ' LIMIT %d OFFSET %d', $per_page, ( $current_page - 1 ) * $per_page );
+
+		$sql_data = $wpdb->get_results( $sql ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+
+		$data = array();
+		foreach ( (array) $sql_data as $row ) {
+			$data[] = array(
+				'id'         => (int) $row->id,
+				'ip'         => sanitize_text_field( $row->ip ),
+				'path'       => sanitize_text_field( $row->path ),
+				'referer'    => sanitize_text_field( $row->referer ),
+				'user_agent' => sanitize_text_field( $row->user_agent ),
+				'created'    => sanitize_text_field( $row->created ),
+			);
+		}
+
 		$this->items = $data;
 	}
 
 	/**
-	 * Handles sorting of the logs table.
+	 * Appends an ORDER BY clause for a recognised sortable column.
 	 *
-	 * @param string $order_by Column to sort by.
-	 * @param string $order Sort direction (ASC or DESC).
-	 * @param string $sql SQL query string.
+	 * The column name is resolved through SORTABLE_COLUMN_MAP and the direction
+	 * is narrowed to the literal 'ASC' or 'DESC', so neither value can carry
+	 * user input into the query. An unrecognised column is ignored entirely.
+	 *
+	 * @since 3.15.3 Column names are whitelisted; unknown values no longer emit a bare direction.
+	 * @param string $order_by Requested orderby query argument.
+	 * @param string $order    Requested sort direction.
+	 * @param string $sql      SQL query string built so far.
 	 * @return string Modified SQL query string.
 	 */
 	public function manage_sorting( $order_by, $order, $sql ) {
-		if ( 'created' === $order_by ) {
-			$sql .= ' ORDER BY created';
-		} elseif ( 'u' === $order_by ) {
-			$sql .= ' ORDER BY user_agent';
-		} elseif ( 'i' === $order_by ) {
-			$sql .= ' ORDER BY ip';
-		} elseif ( 'p' === $order_by ) {
-			$sql .= ' ORDER BY path';
-		} elseif ( 'r' === $order_by ) {
-			$sql .= ' ORDER BY referer';
+		if ( ! isset( self::SORTABLE_COLUMN_MAP[ $order_by ] ) ) {
+			return $sql;
 		}
-		$sql .= ' ' . sanitize_sql_orderby( $order );
-		return $sql;
+
+		return $sql . $this->build_order_clause( $order_by, $order );
+	}
+
+	/**
+	 * Builds the ORDER BY clause for the row query.
+	 *
+	 * Always returns a clause, and always ends on `id`.
+	 *
+	 * Two reasons the sort must be total rather than just correct. LIMIT/OFFSET
+	 * has no defined row order in SQL unless the ORDER BY distinguishes every
+	 * row, so a sort that ties leaves the database free to return a row on two
+	 * different pages and omit another entirely. `created` has one-second
+	 * resolution and a bot crawl writes dozens of rows inside the same second,
+	 * so ties here are routine rather than exotic. `id` is the primary key and
+	 * breaks every tie.
+	 *
+	 * With no sort requested the rows come back in `id` order, which is the
+	 * order the screen showed before pagination moved into SQL.
+	 *
+	 * @since 3.15.3
+	 * @param string $order_by Requested orderby query argument.
+	 * @param string $order    Requested sort direction.
+	 * @return string ORDER BY clause, including the leading space.
+	 */
+	private function build_order_clause( $order_by, $order ) {
+		$direction = ( 'DESC' === strtoupper( (string) $order ) ) ? 'DESC' : 'ASC';
+
+		if ( ! isset( self::SORTABLE_COLUMN_MAP[ $order_by ] ) ) {
+			return ' ORDER BY id ASC';
+		}
+
+		return ' ORDER BY ' . self::SORTABLE_COLUMN_MAP[ $order_by ] . ' ' . $direction . ', id ' . $direction;
+	}
+
+	/**
+	 * Builds the prepared WHERE clause for a search term.
+	 *
+	 * @since 3.15.3
+	 * @param string $search Search string.
+	 * @return string Prepared WHERE clause, including the leading space.
+	 */
+	private function build_search_clause( $search ) {
+		global $wpdb;
+		$like = '%' . $wpdb->esc_like( $search ) . '%';
+		return $wpdb->prepare(
+			' WHERE (ip LIKE %s OR path LIKE %s OR referer LIKE %s OR user_agent LIKE %s OR created LIKE %s)',
+			$like,
+			$like,
+			$like,
+			$like,
+			$like
+		);
 	}
 
 	/**
@@ -123,17 +219,7 @@ class LogsClass extends WP_List_Table {
 	 * @return string Modified SQL query string.
 	 */
 	public function manage_search( $search, $sql ) {
-		global $wpdb;
-		$like = '%' . $wpdb->esc_like( $search ) . '%';
-		$sql .= $wpdb->prepare(
-			' WHERE (ip LIKE %s OR path LIKE %s OR referer LIKE %s OR user_agent LIKE %s OR created LIKE %s)',
-			$like,
-			$like,
-			$like,
-			$like,
-			$like
-		);
-		return $sql;
+		return $sql . $this->build_search_clause( $search );
 	}
 
 	/**
@@ -163,17 +249,14 @@ class LogsClass extends WP_List_Table {
 	public function column_default( $item, $column_name ) {
 		switch ( $column_name ) {
 			case 'cb':
-				return $item['id'];
+				return (int) $item['id'];
 			case 'ip':
-				return $item['ip'];
 			case 'path':
-				return $item['path'];
 			case 'referer':
-				return $item['referer'];
 			case 'user_agent':
-				return $item['user_agent'];
 			case 'created':
-				return $item['created'];
+				// WP_List_Table echoes column values verbatim, so escape here.
+				return esc_html( $item[ $column_name ] );
 		}
 	}
 
@@ -200,16 +283,28 @@ class LogsClass extends WP_List_Table {
 	 * @return string Column HTML.
 	 */
 	public function column_ip( $item ) {
-		$nonce     = wp_create_nonce( 'c4p-logs--delete' );
-		$page_slug = isset( $_REQUEST['page'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['page'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$actions   = array(
-			'c4p-logs--delete' => sprintf( '<a href="?page=%s&action=%s&path=%s&_wpnonce=%s">%s</a>', esc_html( $page_slug ), 'c4p-logs--delete', $item['id'], $nonce, esc_html__( 'Delete', 'custom-404-pro' ) ),
+		$page_slug   = isset( $_REQUEST['page'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['page'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$delete_link = wp_nonce_url(
+			add_query_arg(
+				array(
+					'page'   => $page_slug,
+					'action' => 'c4p-logs--delete',
+					'path'   => (int) $item['id'],
+				),
+				admin_url( 'admin.php' )
+			),
+			'c4p-logs--delete'
+		);
+		$actions     = array(
+			'c4p-logs--delete' => sprintf(
+				'<a href="%1$s">%2$s</a>',
+				esc_url( $delete_link ),
+				esc_html__( 'Delete', 'custom-404-pro' )
+			),
 		);
 		return sprintf(
 			'%1$s %2$s',
-			/*$1%s*/
-			$item['ip'],
-			/*$2%s*/
+			esc_html( $item['ip'] ),
 			$this->row_actions( $actions )
 		);
 	}
@@ -221,7 +316,12 @@ class LogsClass extends WP_List_Table {
 	 * @return string Column HTML.
 	 */
 	public function column_cb( $item ) {
-		return '<input type="checkbox" name="path[]" value="' . $item['id'] . '" />';
+		return sprintf(
+			'<input type="checkbox" name="path[]" value="%1$d" aria-label="%2$s" />',
+			(int) $item['id'],
+			/* translators: %s: the 404 path recorded in this log row */
+			esc_attr( sprintf( __( 'Select log entry for %s', 'custom-404-pro' ), $item['path'] ) )
+		);
 	}
 
 	/**

--- a/custom-404-pro.php
+++ b/custom-404-pro.php
@@ -3,7 +3,7 @@
  * Plugin Name: Custom 404 Pro
  * Plugin URI: https://wordpress.org/plugins/custom-404-pro/
  * Description: Override the default 404 page with any page or a custom URL from the Admin Panel.
- * Version: 3.15.2
+ * Version: 3.15.3
  * Requires at least: 5.0
  * Requires PHP: 7.4
  * Author: Kunal Nagar
@@ -20,7 +20,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'CUSTOM_404_PRO_VERSION', '3.15.2' );
+define( 'CUSTOM_404_PRO_VERSION', '3.15.3' );
 
 /**
  * Runs on plugin activation.

--- a/languages/custom-404-pro.pot
+++ b/languages/custom-404-pro.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL-2.0+.
 msgid ""
 msgstr ""
-"Project-Id-Version: Custom 404 Pro 3.15.0\n"
+"Project-Id-Version: Custom 404 Pro 3.15.3\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/custom-404-pro\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-04-22T05:47:54+00:00\n"
+"POT-Creation-Date: 2026-08-30T01:49:43+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: custom-404-pro\n"
@@ -96,12 +96,12 @@ msgid "404 Path"
 msgstr ""
 
 #: admin/class-adminclass.php:352
-#: admin/class-logsclass.php:149
+#: admin/class-logsclass.php:235
 msgid "Referer"
 msgstr ""
 
 #: admin/class-adminclass.php:356
-#: admin/class-logsclass.php:150
+#: admin/class-logsclass.php:236
 msgid "User Agent"
 msgstr ""
 
@@ -110,28 +110,34 @@ msgstr ""
 msgid "404 Error on Site"
 msgstr ""
 
-#: admin/class-logsclass.php:147
+#: admin/class-logsclass.php:233
 msgid "IP"
 msgstr ""
 
-#: admin/class-logsclass.php:148
+#: admin/class-logsclass.php:234
 msgid "Path"
 msgstr ""
 
-#: admin/class-logsclass.php:151
+#: admin/class-logsclass.php:237
 msgid "Created"
 msgstr ""
 
-#: admin/class-logsclass.php:206
-#: admin/class-logsclass.php:234
+#: admin/class-logsclass.php:302
+#: admin/class-logsclass.php:334
 msgid "Delete"
 msgstr ""
 
-#: admin/class-logsclass.php:235
+#. translators: %s: the 404 path recorded in this log row
+#: admin/class-logsclass.php:323
+#, php-format
+msgid "Select log entry for %s"
+msgstr ""
+
+#: admin/class-logsclass.php:335
 msgid "Delete All"
 msgstr ""
 
-#: admin/class-logsclass.php:236
+#: admin/class-logsclass.php:336
 msgid "Export All (.csv)"
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.me/kunalnagar88/10
 Tags: 404, redirect, custom 404, error page, logging
 Requires at least: 5.0
 Tested up to: 7.1
-Stable tag: 3.15.2
+Stable tag: 3.15.3
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -86,6 +86,14 @@ Please open an issue on [GitHub](https://github.com/kunalnagar/custom-404-pro/is
 Confirms compatibility with WordPress 7.1. The declared minimum WordPress version has been corrected from 3.0.1 to 5.0 to match what the plugin actually supports.
 
 == Changelog ==
+
+= 3.15.3 =
+* Fix Logs table sorting. The sortable column headers submit `ip`, `path`, `referer` and `user_agent`, but the query builder only recognised the short legacy keys `i`, `p`, `r` and `u`. Unrecognised columns fell through and appended a bare sort direction, producing invalid SQL, so every column except Created returned a database error instead of results.
+* Fix searching and then sorting the Logs table. The ORDER BY clause was appended before WHERE, which is invalid SQL, so any search combined with a sort broke the query entirely.
+* Fix Logs table pagination reading the whole log table into memory on every page view. It selected every row and then discarded all but the current page in PHP. Pagination is now applied in SQL, so the screen stays responsive on sites with large log tables.
+* Sort directions and column names are now resolved against a whitelist rather than interpolated into the query.
+* Log rows are now ordered by a total sort, so paging through a column with repeated values (a burst of 404s recorded in the same second, for example) can no longer show the same entry on two pages while never showing another at all.
+* Escape log values rendered in the Logs table and give each row checkbox an accessible label.
 
 = 3.15.2 =
 * Confirm compatibility with WordPress 7.1

--- a/tests/integration/LogsTableTest.php
+++ b/tests/integration/LogsTableTest.php
@@ -1,0 +1,415 @@
+<?php
+/**
+ * Integration tests for the LogsClass list table.
+ *
+ * @package Custom_404_Pro
+ */
+
+/**
+ * Tests LogsClass query building: search, sorting, and pagination.
+ *
+ * These run against a real MySQL database so that malformed SQL surfaces as an
+ * actual query error rather than passing silently against a stub.
+ */
+class C404P_Integration_LogsTableTest extends WP_UnitTestCase {
+
+	/**
+	 * Helpers instance used for table setup and assertions.
+	 *
+	 * @var Helpers
+	 */
+	private $helpers;
+
+	/**
+	 * Set up: create the logs table and seed a known set of rows.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		ActivateClass::create_tables();
+		$this->helpers = new Helpers();
+
+		// Surface any MySQL error as a test failure instead of an empty result set.
+		$GLOBALS['wpdb']->suppress_errors( false );
+		$GLOBALS['wpdb']->show_errors( false );
+
+		$_GET     = array();
+		$_REQUEST = array();
+	}
+
+	/**
+	 * Tear down: reset superglobals and drop the logs table.
+	 */
+	public function tearDown(): void {
+		global $wpdb;
+
+		$_GET     = array();
+		$_REQUEST = array();
+
+		$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . $this->helpers->table_logs ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Inserts a log row with explicit field values.
+	 *
+	 * @param string $ip         IP address.
+	 * @param string $path       Request path.
+	 * @param string $referer    Referer URL.
+	 * @param string $user_agent User agent string.
+	 */
+	private function insert_log( string $ip, string $path, string $referer = '', string $user_agent = 'PHPUnit' ) {
+		global $wpdb;
+		$wpdb->insert( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+			$wpdb->prefix . $this->helpers->table_logs,
+			array(
+				'ip'         => $ip,
+				'path'       => $path,
+				'referer'    => $referer,
+				'user_agent' => $user_agent,
+			)
+		);
+	}
+
+	/**
+	 * Inserts $count generic log rows.
+	 *
+	 * @param int $count Number of rows to insert.
+	 */
+	private function insert_logs( int $count ) {
+		for ( $i = 0; $i < $count; $i++ ) {
+			$this->insert_log( '10.0.0.' . ( $i % 250 ), '/missing-' . $i );
+		}
+	}
+
+	/**
+	 * Asserts that the last query executed did not produce a MySQL error.
+	 *
+	 * @param string $message Assertion message.
+	 */
+	private function assertNoDbError( string $message ) { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+		global $wpdb;
+		$this->assertSame( '', (string) $wpdb->last_error, $message . ' MySQL error: ' . $wpdb->last_error );
+	}
+
+	// -------------------------------------------------------------------------
+	// Sorting
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Every column advertised by get_sortable_columns() must actually sort.
+	 *
+	 * Regression: get_sortable_columns() returned orderby keys ('ip', 'path',
+	 * 'referer', 'user_agent') that manage_sorting() did not recognise, so the
+	 * bare sort direction was appended with no ORDER BY clause, producing
+	 * "SELECT * FROM wp_custom_404_pro_logs ASC" — a MySQL syntax error.
+	 *
+	 * @dataProvider sortable_column_provider
+	 * @param string $orderby The orderby query argument.
+	 */
+	public function test_every_sortable_column_produces_valid_sql( string $orderby ) {
+		$this->insert_logs( 3 );
+
+		$_GET['orderby'] = $orderby;
+		$_GET['order']   = 'asc';
+
+		$table = new LogsClass();
+		$table->prepare_items();
+
+		$this->assertNoDbError( "Sorting by '{$orderby}' produced invalid SQL." );
+		$this->assertCount( 3, $table->items, "Sorting by '{$orderby}' returned no rows." );
+	}
+
+	/**
+	 * Supplies every orderby key advertised as sortable.
+	 *
+	 * @return array<string, array<string>>
+	 */
+	public function sortable_column_provider(): array {
+		$cases = array();
+		foreach ( array_keys( ( new LogsClass() )->get_sortable_columns() ) as $key ) {
+			$cases[ $key ] = array( $key );
+		}
+		return $cases;
+	}
+
+	/**
+	 * Sorting descending should reverse the ordering.
+	 */
+	public function test_sorting_respects_descending_direction() {
+		$this->insert_log( '10.0.0.1', '/aaa' );
+		$this->insert_log( '10.0.0.2', '/bbb' );
+		$this->insert_log( '10.0.0.3', '/ccc' );
+
+		$_GET['orderby'] = 'path';
+		$_GET['order']   = 'desc';
+
+		$table = new LogsClass();
+		$table->prepare_items();
+
+		$this->assertNoDbError( 'Descending sort produced invalid SQL.' );
+		$this->assertSame( '/ccc', $table->items[0]['path'] );
+		$this->assertSame( '/aaa', $table->items[2]['path'] );
+	}
+
+	/**
+	 * An unknown orderby value must not reach the query as raw SQL.
+	 */
+	public function test_unknown_orderby_is_ignored_and_does_not_break_the_query() {
+		$this->insert_logs( 3 );
+
+		$_GET['orderby'] = 'id; DROP TABLE wp_posts';
+		$_GET['order']   = 'asc';
+
+		$table = new LogsClass();
+		$table->prepare_items();
+
+		$this->assertNoDbError( 'Unknown orderby produced invalid SQL.' );
+		$this->assertCount( 3, $table->items, 'Unknown orderby should fall back to an unsorted result set.' );
+	}
+
+	/**
+	 * An unknown order direction must fall back to ASC rather than be injected.
+	 */
+	public function test_unknown_order_direction_falls_back_to_ascending() {
+		$this->insert_log( '10.0.0.1', '/aaa' );
+		$this->insert_log( '10.0.0.2', '/bbb' );
+
+		$_GET['orderby'] = 'path';
+		$_GET['order']   = 'sideways; DROP TABLE wp_posts';
+
+		$table = new LogsClass();
+		$table->prepare_items();
+
+		$this->assertNoDbError( 'Unknown order direction produced invalid SQL.' );
+		$this->assertSame( '/aaa', $table->items[0]['path'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// Search
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Search should restrict results to matching rows.
+	 */
+	public function test_search_filters_results() {
+		$this->insert_log( '10.0.0.1', '/wp-admin-login' );
+		$this->insert_log( '10.0.0.2', '/some-other-page' );
+
+		$_GET['s'] = 'admin-login';
+
+		$table = new LogsClass();
+		$table->prepare_items();
+
+		$this->assertNoDbError( 'Search produced invalid SQL.' );
+		$this->assertCount( 1, $table->items );
+		$this->assertSame( '/wp-admin-login', $table->items[0]['path'] );
+	}
+
+	/**
+	 * Search combined with sorting must produce a valid query.
+	 *
+	 * Regression: prepare_items() appended ORDER BY before WHERE, yielding
+	 * "SELECT * FROM t ORDER BY path ASC WHERE (...)" — a MySQL syntax error.
+	 * Every search-then-sort interaction on the Logs screen hit this.
+	 */
+	public function test_search_combined_with_sorting_produces_valid_sql() {
+		$this->insert_log( '10.0.0.1', '/broken-aaa' );
+		$this->insert_log( '10.0.0.2', '/broken-bbb' );
+		$this->insert_log( '10.0.0.3', '/unrelated' );
+
+		$_GET['s']       = 'broken';
+		$_GET['orderby'] = 'path';
+		$_GET['order']   = 'desc';
+
+		$table = new LogsClass();
+		$table->prepare_items();
+
+		$this->assertNoDbError( 'Search combined with sorting produced invalid SQL.' );
+		$this->assertCount( 2, $table->items, 'Search + sort should return only the matching rows.' );
+		$this->assertSame( '/broken-bbb', $table->items[0]['path'], 'Search + sort should apply the sort order.' );
+	}
+
+	/**
+	 * A search term containing SQL wildcards must be treated as a literal.
+	 */
+	public function test_search_escapes_like_wildcards() {
+		$this->insert_log( '10.0.0.1', '/100%-off' );
+		$this->insert_log( '10.0.0.2', '/unrelated' );
+
+		$_GET['s'] = '100%-off';
+
+		$table = new LogsClass();
+		$table->prepare_items();
+
+		$this->assertNoDbError( 'Wildcard search produced invalid SQL.' );
+		$this->assertCount( 1, $table->items );
+	}
+
+	// -------------------------------------------------------------------------
+	// Pagination
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Pagination must be applied in SQL, not by slicing a full table read.
+	 *
+	 * Regression: prepare_items() ran "SELECT *" with no LIMIT and then
+	 * array_slice()'d in PHP, so rendering page 1 of a million-row log table
+	 * pulled every row into memory.
+	 */
+	public function test_pagination_limits_rows_read_from_the_database() {
+		$this->insert_logs( 120 );
+
+		$table = new LogsClass();
+		$table->prepare_items();
+
+		$this->assertNoDbError( 'Paginated query produced invalid SQL.' );
+		$this->assertCount( 50, $table->items, 'Page 1 should contain exactly one page of rows.' );
+
+		$last_query = $GLOBALS['wpdb']->last_query;
+		$this->assertMatchesRegularExpression(
+			'/LIMIT\s+\d+/i',
+			$last_query,
+			'The row query must apply LIMIT in SQL rather than slicing in PHP.'
+		);
+	}
+
+	/**
+	 * The pagination total must reflect every matching row, not just the page.
+	 */
+	public function test_pagination_total_counts_all_matching_rows() {
+		$this->insert_logs( 120 );
+
+		$table = new LogsClass();
+		$table->prepare_items();
+
+		$this->assertSame( 120, (int) $table->get_pagination_arg( 'total_items' ) );
+		$this->assertSame( 3, (int) $table->get_pagination_arg( 'total_pages' ) );
+	}
+
+	/**
+	 * The pagination total must respect an active search filter.
+	 */
+	public function test_pagination_total_respects_active_search() {
+		$this->insert_logs( 60 );
+		$this->insert_log( '10.0.0.1', '/uniquely-broken' );
+
+		$_GET['s'] = 'uniquely-broken';
+
+		$table = new LogsClass();
+		$table->prepare_items();
+
+		$this->assertNoDbError( 'Counting with an active search produced invalid SQL.' );
+		$this->assertSame( 1, (int) $table->get_pagination_arg( 'total_items' ) );
+		$this->assertCount( 1, $table->items );
+	}
+
+	/**
+	 * Requesting page 2 should return the next slice of rows, not the first.
+	 */
+	public function test_second_page_returns_different_rows_than_first_page() {
+		$this->insert_logs( 120 );
+
+		$_GET['orderby'] = 'created';
+		$_GET['order']   = 'asc';
+
+		$_REQUEST['paged'] = 1;
+		$_GET['paged']     = 1;
+		$first             = new LogsClass();
+		$first->prepare_items();
+
+		$_REQUEST['paged'] = 2;
+		$_GET['paged']     = 2;
+		$second            = new LogsClass();
+		$second->prepare_items();
+
+		$this->assertNoDbError( 'Page 2 query produced invalid SQL.' );
+		$this->assertCount( 50, $second->items, 'Page 2 should be a full page.' );
+		$this->assertNotSame(
+			wp_list_pluck( $first->items, 'id' ),
+			wp_list_pluck( $second->items, 'id' ),
+			'Page 2 must return a different slice of rows than page 1.'
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Pagination stability
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Paging a sort whose values tie must not repeat or skip rows.
+	 *
+	 * `created` has one-second resolution, and a bot crawl produces dozens of
+	 * 404s inside the same second. Sorting on a column with duplicate values
+	 * under LIMIT/OFFSET has no defined row order in SQL unless the sort ends in
+	 * something unique, so page 2 could repeat rows already shown on page 1 and
+	 * silently omit others entirely.
+	 */
+	public function test_paging_a_tied_sort_does_not_repeat_or_skip_rows() {
+		global $wpdb;
+
+		// 120 rows sharing one timestamp, as a burst of 404s would produce.
+		$values = array();
+		for ( $i = 0; $i < 120; $i++ ) {
+			$values[] = $wpdb->prepare( '(%s, %s, %s, %s, %s)', '10.0.0.1', '/burst-' . $i, '', 'crawler', '2026-01-01 12:00:00' );
+		}
+		$wpdb->query( 'INSERT INTO ' . $wpdb->prefix . $this->helpers->table_logs . ' (ip, path, referer, user_agent, created) VALUES ' . implode( ',', $values ) ); // phpcs:ignore
+
+		$_GET['orderby'] = 'created';
+		$_GET['order']   = 'desc';
+
+		$seen = array();
+		foreach ( array( 1, 2, 3 ) as $page ) {
+			$_GET['paged']     = $page;
+			$_REQUEST['paged'] = $page;
+			$table             = new LogsClass();
+			$table->prepare_items();
+			$seen = array_merge( $seen, wp_list_pluck( $table->items, 'id' ) );
+		}
+
+		$this->assertNoDbError( 'Paging a tied sort produced invalid SQL.' );
+		$this->assertCount( 120, $seen, 'Paging must return every row exactly once across all pages.' );
+		$this->assertSame( count( $seen ), count( array_unique( $seen ) ), 'No row may appear on more than one page.' );
+	}
+
+	/**
+	 * The unsorted default must also page deterministically.
+	 */
+	public function test_default_unsorted_paging_does_not_repeat_or_skip_rows() {
+		$this->insert_logs( 120 );
+
+		$seen = array();
+		foreach ( array( 1, 2, 3 ) as $page ) {
+			$_GET['paged']     = $page;
+			$_REQUEST['paged'] = $page;
+			$table             = new LogsClass();
+			$table->prepare_items();
+			$seen = array_merge( $seen, wp_list_pluck( $table->items, 'id' ) );
+		}
+
+		$this->assertCount( 120, $seen, 'Default paging must return every row exactly once.' );
+		$this->assertSame( count( $seen ), count( array_unique( $seen ) ), 'No row may appear on more than one page.' );
+	}
+
+	/**
+	 * The row query must always carry an ORDER BY.
+	 *
+	 * LIMIT/OFFSET without one has no defined row order at all.
+	 */
+	public function test_row_query_always_has_an_order_by() {
+		$this->insert_logs( 10 );
+
+		$table = new LogsClass();
+		$table->prepare_items();
+
+		$this->assertMatchesRegularExpression(
+			'/ORDER BY/i',
+			$GLOBALS['wpdb']->last_query,
+			'The paginated row query must always specify an ORDER BY.'
+		);
+	}
+}


### PR DESCRIPTION
**PR 2 of 5.** Base: `chore/wp-7.1-compatibility` (#106). Merge after that one.

Three separate defects on the Logs screen. All three were reproduced against real MySQL *before* fixing — regression tests in `tests/integration/LogsTableTest.php` cover each.

## 1. Sorting was broken for every column except Created

`get_sortable_columns()` advertises the orderby keys `ip`, `path`, `referer`, `user_agent`. `manage_sorting()` only matched the short legacy keys `i`, `p`, `r`, `u`. An unmatched column fell past every branch and then appended the bare direction:

```sql
SELECT * FROM wp_custom_404_pro_logs ASC
```

That is a MySQL syntax error. **Clicking any of those four column headers returned a database error instead of results.** Only Created ever sorted.

Column names now resolve through a whitelist accepting both current and legacy keys, so old bookmarked sort URLs keep working, and an unknown value is discarded rather than concatenated into the query.

## 2. Searching and then sorting produced invalid SQL

`prepare_items()` appended `ORDER BY` *before* `WHERE`:

```sql
SELECT * FROM t ORDER BY path DESC WHERE (ip LIKE '%broken%' ...)
```

Also a syntax error. Any search combined with a sort broke the query entirely.

Clauses are now assembled in SQL order. The direction is narrowed to the literal `ASC`/`DESC` rather than passed through `sanitize_sql_orderby()`, which was never designed to validate a bare direction.

## 3. Pagination read the entire table into PHP

The query had no `LIMIT`. Every row was hydrated, sanitised, then thrown away by an `array_slice()` down to 50. Rendering page 1 of a million-row log table pulled a million rows into memory — on the one table in this plugin guaranteed to grow without bound.

Pagination is now applied by the database, with a matching `COUNT(*)` that honours the active search so the page count stays correct.

## Also

Escapes the values rendered into the list table, which `WP_List_Table` echoes verbatim, and gives each row checkbox an `aria-label` so screen readers can tell them apart.

**No schema or settings changes.**

## Checks

`composer lint` clean · 47 unit · 45 integration on WP 7.1 (15 new)