### PR TITLE
Version admin assets and label settings fields (v3.15.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,11 @@ Like the plugin? [Buy me a coffee via PayPal](https://www.paypal.me/kunalnagar/1
 
 See [WordPress.org changelog](https://wordpress.org/plugins/custom-404-pro/changelog/) for the full history.
 
+### 3.15.6
+- Fix admin CSS/JS being served with a hardcoded `3.2.0` cache-busting version, leaving browsers on stale assets across updates.
+- Accessibility: associate every Settings field with its label.
+- Remove a leftover `console.warn()` debug call from the admin JavaScript.
+
 ### 3.15.5
 - Security: neutralize spreadsheet formula injection (CSV injection) in the CSV log export, reachable via the attacker-controlled Referer and User Agent columns.
 - Security: escape every value interpolated into the 404 notification email.

--- a/admin/class-adminclass.php
+++ b/admin/class-adminclass.php
@@ -59,6 +59,20 @@ class AdminClass {
 	}
 
 	/**
+	 * Returns the version string used to cache-bust admin assets.
+	 *
+	 * Tied to the plugin version so that a release always invalidates the
+	 * browser cache. The previous hardcoded '3.2.0' meant users kept running
+	 * stale CSS and JS through every update since that release.
+	 *
+	 * @since 3.15.6
+	 * @return string Asset version string.
+	 */
+	public static function asset_version(): string {
+		return defined( 'CUSTOM_404_PRO_VERSION' ) ? CUSTOM_404_PRO_VERSION : '3.2.0';
+	}
+
+	/**
 	 * Enqueues admin stylesheets for plugin pages.
 	 */
 	public function enqueue_styles() {
@@ -66,7 +80,7 @@ class AdminClass {
 			if ( array_key_exists( 'page', $_REQUEST ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				$request = sanitize_text_field( wp_unslash( $_REQUEST['page'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				if ( 'c4p-settings' === $request || 'c4p-main' === $request || 'c4p-about' === $request ) {
-					wp_enqueue_style( 'custom-404-pro-admin-css', plugin_dir_url( __FILE__ ) . 'css/custom-404-pro-admin.css', array(), '3.2.0' );
+					wp_enqueue_style( 'custom-404-pro-admin-css', plugin_dir_url( __FILE__ ) . 'css/custom-404-pro-admin.css', array(), self::asset_version() );
 				}
 			}
 		}
@@ -80,7 +94,7 @@ class AdminClass {
 			if ( array_key_exists( 'page', $_REQUEST ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				$request = sanitize_text_field( wp_unslash( $_REQUEST['page'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				if ( 'c4p-settings' === $request || 'c4p-main' === $request ) {
-					wp_enqueue_script( 'custom-404-pro-admin-js', plugin_dir_url( __FILE__ ) . 'js/custom-404-pro-admin.js', array( 'jquery' ), '3.2.0', false );
+					wp_enqueue_script( 'custom-404-pro-admin-js', plugin_dir_url( __FILE__ ) . 'js/custom-404-pro-admin.js', array( 'jquery' ), self::asset_version(), false );
 				}
 			}
 		}
@@ -113,7 +127,6 @@ class AdminClass {
 	 * Handles the global redirect settings form submission.
 	 */
 	public function form_settings_global_redirect() {
-		$nonce = isset( $_POST['form-settings-global-redirect'] ) ? sanitize_text_field( wp_unslash( $_POST['form-settings-global-redirect'] ) ) : '';
 		if ( check_admin_referer( 'form-settings-global-redirect', 'form-settings-global-redirect' ) && current_user_can( 'manage_options' ) ) {
 			$mode = isset( $_POST['mode'] ) ? sanitize_text_field( wp_unslash( $_POST['mode'] ) ) : '';
 			$page = isset( $_POST['mode_page'] ) ? sanitize_text_field( wp_unslash( $_POST['mode_page'] ) ) : '';
@@ -130,7 +143,6 @@ class AdminClass {
 	 * Handles the general settings form submission.
 	 */
 	public function form_settings_general() {
-		$nonce = isset( $_POST['form-settings-general'] ) ? sanitize_text_field( wp_unslash( $_POST['form-settings-general'] ) ) : '';
 		if ( check_admin_referer( 'form-settings-general', 'form-settings-general' ) && current_user_can( 'manage_options' ) ) {
 			$send_email                = isset( $_POST['send_email'] ) ? sanitize_text_field( wp_unslash( $_POST['send_email'] ) ) : '';
 			$logging_enabled           = isset( $_POST['logging_enabled'] ) ? sanitize_text_field( wp_unslash( $_POST['logging_enabled'] ) ) : '';

--- a/admin/js/custom-404-pro-admin.js
+++ b/admin/js/custom-404-pro-admin.js
@@ -14,7 +14,6 @@
 						var val   = $that.val();
 						$( '#mode_url' ).removeAttr( 'required' );
 						$( '#c4p_page, #c4p_url' ).hide();
-						console.warn( val );
 						if (val === 'page') {
 								$( '#c4p_page' ).show();
 						} else if (val === 'url') {

--- a/admin/views/settings-general.php
+++ b/admin/views/settings-general.php
@@ -20,7 +20,7 @@ $log_retention_days  = isset( $options['log_retention_days'] ) ? (int) $options[
 		<table class="form-table">
 			<tbody>
 			<tr>
-				<th><?php esc_html_e( 'Email', 'custom-404-pro' ); ?></th>
+				<th><label for="c4p_log_email"><?php esc_html_e( 'Email', 'custom-404-pro' ); ?></label></th>
 				<td>
 					<input type="checkbox" id="c4p_log_email" name="send_email" <?php echo (bool) $send_email ? 'checked' : ''; ?> />
 					<p class="description">
@@ -36,9 +36,9 @@ $log_retention_days  = isset( $options['log_retention_days'] ) ? (int) $options[
 				</td>
 			</tr>
 			<tr>
-				<th><?php esc_html_e( 'Email Notification Cooldown', 'custom-404-pro' ); ?></th>
+				<th><label for="c4p_email_cooldown"><?php esc_html_e( 'Email Notification Cooldown', 'custom-404-pro' ); ?></label></th>
 				<td>
-					<select name="email_cooldown">
+					<select id="c4p_email_cooldown" name="email_cooldown">
 						<option value="900" <?php echo 900 === $email_cooldown ? 'selected' : ''; ?>><?php esc_html_e( '15 minutes', 'custom-404-pro' ); ?></option>
 						<option value="1800" <?php echo 1800 === $email_cooldown ? 'selected' : ''; ?>><?php esc_html_e( '30 minutes', 'custom-404-pro' ); ?></option>
 						<option value="3600" <?php echo 3600 === $email_cooldown ? 'selected' : ''; ?>><?php esc_html_e( '1 hour', 'custom-404-pro' ); ?></option>
@@ -58,9 +58,9 @@ $log_retention_days  = isset( $options['log_retention_days'] ) ? (int) $options[
 				</td>
 			</tr>
 			<tr>
-				<th><?php esc_html_e( 'Logging Status', 'custom-404-pro' ); ?></th>
+				<th><label for="c4p_logging_enabled"><?php esc_html_e( 'Logging Status', 'custom-404-pro' ); ?></label></th>
 				<td>
-					<select name="logging_enabled">
+					<select id="c4p_logging_enabled" name="logging_enabled">
 						<option value="enabled" <?php echo (bool) $logging_enabled ? 'selected' : ''; ?>>
 							<?php esc_html_e( 'Enabled', 'custom-404-pro' ); ?>
 						</option>
@@ -81,7 +81,7 @@ $log_retention_days  = isset( $options['log_retention_days'] ) ? (int) $options[
 				</td>
 			</tr>
 			<tr>
-				<th><?php esc_html_e( 'Log IP', 'custom-404-pro' ); ?></th>
+				<th><label for="c4p_log_ip"><?php esc_html_e( 'Log IP', 'custom-404-pro' ); ?></label></th>
 				<td>
 					<input type="checkbox" id="c4p_log_ip" name="log_ip" <?php echo (bool) $log_ip ? 'checked' : ''; ?> />
 					<p class="description">
@@ -97,9 +97,9 @@ $log_retention_days  = isset( $options['log_retention_days'] ) ? (int) $options[
 				</td>
 			</tr>
 			<tr>
-				<th><?php esc_html_e( 'Redirect Code', 'custom-404-pro' ); ?></th>
+				<th><label for="c4p_redirect_error_code"><?php esc_html_e( 'Redirect Code', 'custom-404-pro' ); ?></label></th>
 				<td>
-					<select name="redirect_error_code">
+					<select id="c4p_redirect_error_code" name="redirect_error_code">
 						<option value="301" <?php echo 301 === $redirect_error_code ? 'selected' : ''; ?>>301
 						</option>
 						<option value="302" <?php echo 302 === $redirect_error_code ? 'selected' : ''; ?>>302
@@ -115,9 +115,9 @@ $log_retention_days  = isset( $options['log_retention_days'] ) ? (int) $options[
 				</td>
 			</tr>
 			<tr>
-				<th><?php esc_html_e( 'Max Log Count', 'custom-404-pro' ); ?></th>
+				<th><label for="c4p_log_retention_count"><?php esc_html_e( 'Max Log Count', 'custom-404-pro' ); ?></label></th>
 				<td>
-					<input type="number" name="log_retention_count" value="<?php echo esc_attr( $log_retention_count ); ?>" min="0" step="1" />
+					<input type="number" id="c4p_log_retention_count" name="log_retention_count" value="<?php echo esc_attr( $log_retention_count ); ?>" min="0" step="1" />
 					<p class="description">
 						<?php
 						echo wp_kses_post(
@@ -131,9 +131,9 @@ $log_retention_days  = isset( $options['log_retention_days'] ) ? (int) $options[
 				</td>
 			</tr>
 			<tr>
-				<th><?php esc_html_e( 'Max Log Age (days)', 'custom-404-pro' ); ?></th>
+				<th><label for="c4p_log_retention_days"><?php esc_html_e( 'Max Log Age (days)', 'custom-404-pro' ); ?></label></th>
 				<td>
-					<input type="number" name="log_retention_days" value="<?php echo esc_attr( $log_retention_days ); ?>" min="0" step="1" />
+					<input type="number" id="c4p_log_retention_days" name="log_retention_days" value="<?php echo esc_attr( $log_retention_days ); ?>" min="0" step="1" />
 					<p class="description">
 						<?php
 						echo wp_kses_post(

--- a/admin/views/settings-global-redirect.php
+++ b/admin/views/settings-global-redirect.php
@@ -25,7 +25,7 @@ if ( 'page' === $redirect_mode ) {
 		<table class="form-table">
 			<tbody>
 			<tr>
-				<th><?php esc_html_e( 'Mode', 'custom-404-pro' ); ?></th>
+				<th><label for="c4p_mode"><?php esc_html_e( 'Mode', 'custom-404-pro' ); ?></label></th>
 				<td>
 					<select id="c4p_mode" name="mode">
 						<option value=""><?php esc_html_e( 'None', 'custom-404-pro' ); ?></option>
@@ -59,9 +59,9 @@ if ( 'page' === $redirect_mode ) {
 				</td>
 			</tr>
 			<tr id="c4p_page" class="select-page">
-				<th><?php esc_html_e( 'Select a Page', 'custom-404-pro' ); ?></th>
+				<th><label for="c4p_mode_page"><?php esc_html_e( 'Select a Page', 'custom-404-pro' ); ?></label></th>
 				<td>
-					<select name="mode_page">
+					<select id="c4p_mode_page" name="mode_page">
 						<option value=""><?php esc_html_e( 'None (Default Error Page)', 'custom-404-pro' ); ?></option>
 		<?php foreach ( $wp_pages as $wp_page ) : ?>
 							<option value="<?php echo esc_attr( $wp_page->ID ); ?>" <?php echo ( $wp_page->ID === (int) $redirect_mode_page ) ? 'selected' : ''; ?>>
@@ -75,7 +75,7 @@ if ( 'page' === $redirect_mode ) {
 				</td>
 			</tr>
 			<tr id="c4p_url" class="select-url">
-				<th><?php esc_html_e( 'Enter a URL', 'custom-404-pro' ); ?></th>
+				<th><label for="mode_url"><?php esc_html_e( 'Enter a URL', 'custom-404-pro' ); ?></label></th>
 				<td>
 					<input id="mode_url" name="mode_url" type="url" class="regular-text" value="<?php echo esc_url( $redirect_mode_url ); ?>" autocomplete="off" <?php echo ( ! empty( $redirect_mode_url ) ) ? 'required = "required"' : ''; ?>>
 					<p class="description">

--- a/custom-404-pro.php
+++ b/custom-404-pro.php
@@ -3,7 +3,7 @@
  * Plugin Name: Custom 404 Pro
  * Plugin URI: https://wordpress.org/plugins/custom-404-pro/
  * Description: Override the default 404 page with any page or a custom URL from the Admin Panel.
- * Version: 3.15.5
+ * Version: 3.15.6
  * Requires at least: 5.0
  * Requires PHP: 7.4
  * Author: Kunal Nagar
@@ -20,7 +20,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'CUSTOM_404_PRO_VERSION', '3.15.5' );
+define( 'CUSTOM_404_PRO_VERSION', '3.15.6' );
 
 /**
  * Runs on plugin activation.

--- a/languages/custom-404-pro.pot
+++ b/languages/custom-404-pro.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL-2.0+.
 msgid ""
 msgstr ""
-"Project-Id-Version: Custom 404 Pro 3.15.5\n"
+"Project-Id-Version: Custom 404 Pro 3.15.6\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/custom-404-pro\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-08-30T02:16:30+00:00\n"
+"POT-Creation-Date: 2026-08-30T02:17:04+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: custom-404-pro\n"
@@ -54,59 +54,59 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: admin/class-adminclass.php:122
-#: admin/class-adminclass.php:157
+#: admin/class-adminclass.php:135
+#: admin/class-adminclass.php:169
 msgid "Saved!"
 msgstr ""
 
-#: admin/class-adminclass.php:176
+#: admin/class-adminclass.php:188
 msgid "Log(s) successfully deleted!"
 msgstr ""
 
-#: admin/class-adminclass.php:181
+#: admin/class-adminclass.php:193
 msgid "Please select a few logs to delete and try again."
 msgstr ""
 
-#: admin/class-adminclass.php:188
+#: admin/class-adminclass.php:200
 msgid "All Logs successfully deleted!"
 msgstr ""
 
 #. translators: %d: number of log rows pruned
-#: admin/class-adminclass.php:199
+#: admin/class-adminclass.php:211
 #, php-format
 msgid "Pruned %d log row."
 msgid_plural "Pruned %d log rows."
 msgstr[0] ""
 msgstr[1] ""
 
-#: admin/class-adminclass.php:343
+#: admin/class-adminclass.php:355
 msgid "Here are the 404 Log Details:"
 msgstr ""
 
-#: admin/class-adminclass.php:346
+#: admin/class-adminclass.php:358
 msgid "Site"
 msgstr ""
 
-#: admin/class-adminclass.php:350
+#: admin/class-adminclass.php:362
 msgid "User IP"
 msgstr ""
 
-#: admin/class-adminclass.php:354
+#: admin/class-adminclass.php:366
 msgid "404 Path"
 msgstr ""
 
-#: admin/class-adminclass.php:358
+#: admin/class-adminclass.php:370
 #: admin/class-logsclass.php:235
 msgid "Referer"
 msgstr ""
 
-#: admin/class-adminclass.php:362
+#: admin/class-adminclass.php:374
 #: admin/class-logsclass.php:236
 msgid "User Agent"
 msgstr ""
 
 #. translators: email subject sent to the site admin when a 404 is logged
-#: admin/class-adminclass.php:369
+#: admin/class-adminclass.php:381
 msgid "404 Error on Site"
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.me/kunalnagar88/10
 Tags: 404, redirect, custom 404, error page, logging
 Requires at least: 5.0
 Tested up to: 7.1
-Stable tag: 3.15.5
+Stable tag: 3.15.6
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -86,6 +86,12 @@ Please open an issue on [GitHub](https://github.com/kunalnagar/custom-404-pro/is
 Confirms compatibility with WordPress 7.1. The declared minimum WordPress version has been corrected from 3.0.1 to 5.0 to match what the plugin actually supports.
 
 == Changelog ==
+
+= 3.15.6 =
+* Fix the admin stylesheet and script being served with a hardcoded cache-busting version of 3.2.0. Because the value never changed, browsers kept serving cached copies of both files across every update since that release. They are now versioned with the current plugin version.
+* Accessibility: associate every field on the Settings screens with its label, so screen readers announce each control instead of reading an unlabelled input.
+* Remove a leftover console.warn() debug call from the admin JavaScript.
+* Remove two unused variables in the settings form handlers.
 
 = 3.15.5 =
 * Security: neutralize spreadsheet formula injection in the CSV log export. The Referer and User Agent columns are supplied by whoever triggered the 404, and were written to the export unescaped, so a crafted request could plant a formula that executed when an administrator opened the file in Excel, LibreOffice or Google Sheets.

--- a/tests/AdminClassTest.php
+++ b/tests/AdminClassTest.php
@@ -263,4 +263,34 @@ class AdminClassTest extends TestCase {
 		$admin = new AdminClass();
 		$this->assertFalse( $admin->is_email_on_cooldown() );
 	}
+
+	// ------------------------------------------------------------------
+	// Asset cache busting
+	// ------------------------------------------------------------------
+
+	/**
+	 * Admin assets must be versioned with the plugin version so that each
+	 * release invalidates the browser cache. This was pinned to a hardcoded
+	 * '3.2.0' for many releases, leaving users on stale CSS and JS.
+	 */
+	public function test_asset_version_tracks_the_plugin_version() {
+		$this->assertSame( CUSTOM_404_PRO_VERSION, AdminClass::asset_version() );
+	}
+
+	/**
+	 * The asset version must no longer be the stale hardcoded value.
+	 */
+	public function test_asset_version_is_not_the_stale_hardcoded_value() {
+		$this->assertNotSame( '3.2.0', AdminClass::asset_version() );
+	}
+
+	/**
+	 * asset_version() must be callable statically from the enqueue callbacks.
+	 */
+	public function test_asset_version_is_public_static() {
+		$ref    = new ReflectionClass( AdminClass::class );
+		$method = $ref->getMethod( 'asset_version' );
+		$this->assertTrue( $method->isPublic(), 'asset_version must be public' );
+		$this->assertTrue( $method->isStatic(), 'asset_version must be static' );
+	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -31,6 +31,16 @@ if ( ! defined( 'DAY_IN_SECONDS' ) ) {
 	define( 'DAY_IN_SECONDS', 86400 );
 }
 
+// Mirror the plugin version constant, read from the plugin file rather than
+// hardcoded, so version-dependent behaviour (asset cache busting, the db-version
+// upgrade gate) is testable without loading WordPress.
+if ( ! defined( 'CUSTOM_404_PRO_VERSION' ) ) {
+	$_c404p_main = file_get_contents( dirname( __DIR__ ) . '/custom-404-pro.php' );
+	preg_match( "/define\(\s*'CUSTOM_404_PRO_VERSION',\s*'([^']+)'\s*\)/", $_c404p_main, $_c404p_match );
+	define( 'CUSTOM_404_PRO_VERSION', $_c404p_match[1] ?? '0.0.0' );
+	unset( $_c404p_main, $_c404p_match );
+}
+
 /**
  * Stub for WordPress apply_filters().
  *


### PR DESCRIPTION
**PR 4 of 5.** Base: `fix/csv-injection-and-email-escaping` (#108). Merge after that one.

## Asset cache busting

Both admin assets were enqueued with a literal `'3.2.0'` as the version argument:

```php
wp_enqueue_style( 'custom-404-pro-admin-css', ..., array(), '3.2.0' );
wp_enqueue_script( 'custom-404-pro-admin-js', ..., array( 'jquery' ), '3.2.0', false );
```

That string has not changed since the 3.2.0 release, so the asset URLs never changed either and browsers went on serving cached copies through every update since. **Any fix shipped in those two files silently failed to reach users who had already loaded the admin screens.**

Both now use `AdminClass::asset_version()`, returning `CUSTOM_404_PRO_VERSION`, so each release invalidates the cache.

## Accessibility

Every control on both Settings tabs sat in a table row whose `<th>` held plain text with no programmatic association to the input. Screen readers announced unlabelled checkboxes, selects and number fields.

The headings are now `<label for="...">` tied to the matching control — which also makes the label text a click target.

## Housekeeping

- Drops a `console.warn()` left in the shipped admin JavaScript.
- Drops two `$nonce` variables in the settings form handlers that were assigned and never read. Nonce verification happens via `check_admin_referer()` on the following line and is unaffected.

The unit bootstrap now derives `CUSTOM_404_PRO_VERSION` from the plugin file rather than hardcoding it, so the asset-version assertions cannot drift from the real release number.

**No schema or settings changes.**

## Checks

`composer lint` clean · 60 unit (3 new) · 45 integration on WP 7.1