### PR TITLE
Remove mis-published SVN tag 3.15.3

### DIFF
--- a/.github/workflows/remove-svn-tag.yml
+++ b/.github/workflows/remove-svn-tag.yml
@@ -1,0 +1,92 @@
+name: Remove mis-published SVN tag
+
+# One-off maintenance job.
+#
+# Release automation published tag 3.15.3 to the plugin SVN containing the
+# 3.15.2 build. The stable tag never pointed at it, so no site was ever offered
+# it as an update, but it is listed under the plugin's previous versions and is
+# downloadable, where it presents 3.15.2 code as though it were 3.15.3.
+#
+# Deleting an SVN tag needs the .org credentials, which live only as repository
+# secrets, so the removal has to run here rather than from a workstation.
+#
+# This workflow is intended to be deleted once it has run.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'SVN tag to remove'
+        required: true
+        default: '3.15.3'
+      confirm:
+        description: 'Type the tag again to confirm deletion'
+        required: true
+
+jobs:
+  remove-tag:
+    name: Remove SVN tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Subversion
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq subversion
+
+      - name: Remove the tag
+        env:
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          TAG: ${{ inputs.tag }}
+          CONFIRM: ${{ inputs.confirm }}
+        run: |
+          set -euo pipefail
+
+          SLUG=custom-404-pro
+          BASE="https://plugins.svn.wordpress.org/${SLUG}"
+          TAG_URL="${BASE}/tags/${TAG}"
+
+          # Guard 1: the two inputs must agree, so a stray dispatch cannot
+          # delete whatever happens to sit in the default field.
+          if [ "$TAG" != "$CONFIRM" ]; then
+            echo "::error::Confirmation '${CONFIRM}' does not match tag '${TAG}'."
+            exit 1
+          fi
+
+          # Guard 2: never touch the version the plugin is currently serving.
+          STABLE=$(curl -fsSL "${BASE}/trunk/readme.txt" | grep -m1 '^Stable tag:' | awk '{print $3}')
+          echo "Current stable tag on trunk: ${STABLE}"
+          if [ "$TAG" = "$STABLE" ]; then
+            echo "::error::Refusing to delete ${TAG}: it is the current stable release."
+            exit 1
+          fi
+
+          # Guard 3: the tag has to exist.
+          if ! svn ls "$TAG_URL" > /dev/null 2>&1; then
+            echo "Tag ${TAG} does not exist. Nothing to do."
+            exit 0
+          fi
+
+          # Guard 4: only remove a tag whose contents disagree with its name.
+          # A correctly published tag declares its own version; this one does
+          # not, which is precisely what makes it safe and necessary to remove.
+          INNER=$(svn cat "${TAG_URL}/readme.txt" | grep -m1 '^Stable tag:' | awk '{print $3}')
+          echo "Tag ${TAG} declares version: ${INNER}"
+          if [ "$INNER" = "$TAG" ]; then
+            echo "::error::Refusing to delete ${TAG}: it correctly declares its own version, so it is a legitimate release."
+            exit 1
+          fi
+
+          echo "Removing mis-published tag ${TAG} (contains ${INNER})..."
+          svn rm "$TAG_URL" \
+            -m "Remove tag ${TAG}, published in error with the ${INNER} build" \
+            --username "$SVN_USERNAME" \
+            --password "$SVN_PASSWORD" \
+            --non-interactive \
+            --no-auth-cache \
+            --trust-server-cert
+
+          # Verify.
+          if svn ls "$TAG_URL" > /dev/null 2>&1; then
+            echo "::error::Tag ${TAG} still present after deletion."
+            exit 1
+          fi
+          echo "✓ Tag ${TAG} removed."


### PR DESCRIPTION
One-off maintenance job. **Intended to be deleted once it has run** — a follow-up PR removes it.

## Why

Release automation published SVN tag `3.15.3` containing the **3.15.2 build**. `Stable tag` never pointed at it, so no site was ever offered it as an update — but it *is* listed among the plugin's previous versions and is downloadable:

```
tags/3.15.3/readme.txt        ->  Stable tag: 3.15.2
tags/3.15.3/custom-404-pro.php ->  * Version: 3.15.2
```

So anyone using **Advanced → Previous Versions** can download "3.15.3" and get 3.15.2 code. That is the part worth fixing.

Removing an SVN tag needs the WordPress.org credentials, which exist only as repository secrets (`SVN_USERNAME` / `SVN_PASSWORD`), so this has to run inside Actions rather than from a workstation.

## Safety

A workflow holding SVN credentials that deletes things deserves care, so it is guarded four ways and refuses rather than guesses:

1. **Two matching inputs** — the tag must be typed twice, so a stray dispatch cannot delete whatever sits in the default field.
2. **Never the current release** — it reads `Stable tag` from trunk and refuses if the target matches.
3. **Must exist** — exits cleanly if there is nothing there.
4. **Contents must disagree with the name** — it only deletes a tag whose declared version differs from the tag name. A correctly published tag declares its own version, so **a legitimate release can never satisfy this condition.**

It verifies the tag is gone afterwards and fails if not.

No plugin code is touched.