### PR TITLE
Fix pipefail abort in SVN tag removal job

### DIFF
--- a/.github/workflows/remove-svn-tag.yml
+++ b/.github/workflows/remove-svn-tag.yml
@@ -52,7 +52,10 @@ jobs:
           fi
 
           # Guard 2: never touch the version the plugin is currently serving.
-          STABLE=$(curl -fsSL "${BASE}/trunk/readme.txt" | grep -m1 '^Stable tag:' | awk '{print $3}')
+          # Read to a file rather than piping: `grep -m1` closes the pipe as
+          # soon as it matches, which makes curl exit 23 under `pipefail`.
+          curl -fsSL "${BASE}/trunk/readme.txt" -o trunk-readme.txt
+          STABLE=$(awk '/^Stable tag:/ {print $3; exit}' trunk-readme.txt)
           echo "Current stable tag on trunk: ${STABLE}"
           if [ "$TAG" = "$STABLE" ]; then
             echo "::error::Refusing to delete ${TAG}: it is the current stable release."
@@ -68,7 +71,8 @@ jobs:
           # Guard 4: only remove a tag whose contents disagree with its name.
           # A correctly published tag declares its own version; this one does
           # not, which is precisely what makes it safe and necessary to remove.
-          INNER=$(svn cat "${TAG_URL}/readme.txt" | grep -m1 '^Stable tag:' | awk '{print $3}')
+          svn cat "${TAG_URL}/readme.txt" > tag-readme.txt
+          INNER=$(awk '/^Stable tag:/ {print $3; exit}' tag-readme.txt)
           echo "Tag ${TAG} declares version: ${INNER}"
           if [ "$INNER" = "$TAG" ]; then
             echo "::error::Refusing to delete ${TAG}: it correctly declares its own version, so it is a legitimate release."


### PR DESCRIPTION
The first dispatch of #112's workflow failed **before reaching any destructive step**:

```
curl: (23) Failure writing output to destination
Process completed with exit code 23
```

## Cause

The guards piped a transfer into `grep -m1`:

```bash
STABLE=$(curl -fsSL "${BASE}/trunk/readme.txt" | grep -m1 '^Stable tag:' | awk '{print $3}')
```

`grep -m1` exits the moment it matches, closing the pipe while curl is still writing. curl aborts with exit 23, and `set -o pipefail` turns that into a job failure. `svn cat | grep -m1` had the same problem.

## Fix

Both readmes are fetched to disk and parsed with a single `awk` pass, so nothing closes a pipe early. **Guard logic is unchanged.**

Rehearsed against both a mis-published and a legitimate tag to confirm the safety check still refuses the latter:

```
tag 3.15.3  declares 3.15.2  -> proceed (mis-published)
tag 3.16.0  declares 3.16.0  -> REFUSE (legitimate release)
```